### PR TITLE
Add: Train Script support for Yolact

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,29 +1,30 @@
+import logging
+
+from sparseml.pytorch.utils import TensorBoardLogger
+from torch.cuda import amp
+
 from data import *
 from utils.augmentations import SSDAugmentation, BaseTransform
 from utils.functions import MovingAverage, SavePath
 from utils.logger import Log
 from utils import timer
 from layers.modules import MultiBoxLoss
+from utils.sparse import SparseMLWrapper
+from utils.zoo import is_valid_stub, download_checkpoint_from_stub
 from yolact import Yolact
 import os
-import sys
 import time
 import math, random
-from pathlib import Path
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torch.optim as optim
-import torch.backends.cudnn as cudnn
-import torch.nn.init as init
 import torch.utils.data as data
-import numpy as np
 import argparse
 import datetime
 
 # Oof
 import eval as eval_script
-
+logger = logging.getLogger(__name__)
 def str2bool(v):
     return v.lower() in ("yes", "true", "t", "1")
 
@@ -34,7 +35,11 @@ parser.add_argument('--batch_size', default=8, type=int,
                     help='Batch size for training')
 parser.add_argument('--resume', default=None, type=str,
                     help='Checkpoint state_dict file to resume training from. If this is "interrupt"'\
-                         ', the model will resume training from the interrupt file.')
+                         ', the model will resume training from the interrupt file. Can also be set to True;'
+                        'along with the --ckpt argument to resume training from a SparseZoo stub or local checkpoint'
+                    )
+parser.add_argument('--ckpt', type=str, default=None,
+                    help="Path to a Yolact checkpoint/SparseZoo stub used only if --resume is True")
 parser.add_argument('--start_iter', default=-1, type=int,
                     help='Resume training at this iter. If this is -1, the iteration will be'\
                          'determined from the file name.')
@@ -78,6 +83,21 @@ parser.add_argument('--batch_alloc', default=None, type=str,
                     help='If using multiple GPUS, you can set this to be a comma separated list detailing which GPUs should get what local batch size (It should add up to your total batch size).')
 parser.add_argument('--no_autoscale', dest='autoscale', action='store_false',
                     help='YOLACT will automatically scale the lr and the number of iterations depending on the batch size. Set this if you want to disable that.')
+parser.add_argument('--recipe', type=str, default=None,
+                    help="Path to a sparsification recipe, can also be a "
+                         "SparseZoo recipe stub, if provided the recipe "
+                         "stored with the checkpoint is ignored"
+                    )
+parser.add_argument('--override_checkpoint_epoch',
+                    default=True,
+                    type=bool,
+                    help="True to to override epoch # saved in the checkpoint and start from 0"
+                    )
+parser.add_argument('--fp16',
+                    action='store_true',
+                    help ='flag to switch on fp16 while training'
+                    )
+parser.add_argument('--wandb', action='store_true', help="Flag to use wandb logging")
 
 parser.set_defaults(keep_latest=False, log=True, log_gpu=False, interrupt=True, autoscale=True)
 args = parser.parse_args()
@@ -201,18 +221,29 @@ def train():
         args.resume = SavePath.get_interrupt(args.save_folder)
     elif args.resume == 'latest':
         args.resume = SavePath.get_latest(args.save_folder, cfg.name)
+    elif str2bool(args.resume):
+        if is_valid_stub(args.ckpt):
+            args.resume = download_checkpoint_from_stub(args.ckpt)
+        else:
+            args.resume = args.ckpt
 
-    if args.resume is not None:
-        print('Resuming training, loading {}...'.format(args.resume))
-        yolact_net.load_weights(args.resume)
-
+    if args.resume and args.resume.lower() not in ("no", "false", "f", "0"):
+        print('Resuming training, loading checkpoint {}...'.format(args.resume))
+        checkpoint_epoch, checkpoint_recipe, sparseml_wrapper = yolact_net.load_checkpoint(args.resume, args.recipe)
+        start_epoch = 0
+        if checkpoint_epoch and checkpoint_recipe: start_epoch = checkpoint_epoch
+        if args.override_checkpoint_epoch: start_epoch = 0
+        args.recipe = args.recipe or checkpoint_recipe
         if args.start_iter == -1:
             args.start_iter = SavePath.from_str(args.resume).iteration
     else:
         print('Initializing weights...')
         yolact_net.init_weights(backbone_path=args.save_folder + cfg.backbone.path)
+        start_epoch= 0
+        sparseml_wrapper = SparseMLWrapper(yolact_net, args.recipe)
+        sparseml_wrapper.initialize(start_epoch=start_epoch)
 
-    optimizer = optim.SGD(net.parameters(), lr=args.lr, momentum=args.momentum,
+    optimizer = optim.SGD(yolact_net.parameters(), lr=args.lr, momentum=args.momentum,
                           weight_decay=args.decay)
     criterion = MultiBoxLoss(num_classes=cfg.num_classes,
                              pos_threshold=cfg.positive_iou_threshold,
@@ -242,7 +273,8 @@ def train():
 
     epoch_size = len(dataset) // args.batch_size
     num_epochs = math.ceil(cfg.max_iter / epoch_size)
-    
+
+
     # Which learning rate adjustment step are we on? lr' = lr * gamma ^ step_index
     step_index = 0
 
@@ -261,8 +293,30 @@ def train():
     print('Begin training!')
     print()
     # try-except so you can use ctrl+c to save early and stop training
+    # SparseML Integration
+    half_precision = args.fp16 and args.device != 'cpu'
+    scaler = amp.GradScaler(enabled=half_precision)
+    sparseml_wrapper.initialize_loggers(logger, tb_writer=TensorBoardLogger,
+                                        wandb_logger=args.wandb, rank=-1)
+    scaler = sparseml_wrapper.modify(scaler, optimizer, yolact_net, data_loader)
+    num_epochs = sparseml_wrapper.check_epoch_override(num_epochs)
+
+    max_steps = cfg.max_iter
+    print(f"num epochs: {num_epochs}")
+    print(f"Steps to train: {(num_epochs - start_epoch) * len(data_loader)}" )
+
+    # try-except so you can use ctrl+c to save early and stop training
+    # SparseML Integration
+
     try:
-        for epoch in range(num_epochs):
+        for epoch in range(start_epoch, num_epochs):
+            if sparseml_wrapper.qat_active(epoch):
+                logger.info(
+                    'Disabling half precision, QAT scheduled to run'
+                    )
+                scaler._enabled = False
+                half_precision = False
+
             # Resume from start_iter
             if (epoch+1)*epoch_size < iteration:
                 continue
@@ -286,37 +340,48 @@ def train():
                         # Reset the loss averages because things might have changed
                         for avg in loss_avgs:
                             avg.reset()
-                
+
                 # If a config setting was changed, remove it from the list so we don't keep checking
                 if changed:
                     cfg.delayed_settings = [x for x in cfg.delayed_settings if x[0] > iteration]
 
                 # Warm up by linearly interpolating the learning rate from some smaller value
-                if cfg.lr_warmup_until > 0 and iteration <= cfg.lr_warmup_until:
+
+                needs_manual_lr_update = (
+                                                 cfg.lr_warmup_until > 0 and
+                                          iteration <=cfg.lr_warmup_until and
+                                not sparseml_wrapper.should_override_scheduler()
+                )
+                if needs_manual_lr_update:
                     set_lr(optimizer, (args.lr - cfg.lr_warmup_init) * (iteration / cfg.lr_warmup_until) + cfg.lr_warmup_init)
 
                 # Adjust the learning rate at the given iterations, but also if we resume from past that iteration
-                while step_index < len(cfg.lr_steps) and iteration >= cfg.lr_steps[step_index]:
+                while not sparseml_wrapper.should_override_scheduler() and \
+                        step_index < len(cfg.lr_steps) and iteration >= \
+                        cfg.lr_steps[step_index]:
                     step_index += 1
                     set_lr(optimizer, args.lr * (args.gamma ** step_index))
-                
+
                 # Zero the grad to get ready to compute gradients
                 optimizer.zero_grad()
 
-                # Forward Pass + Compute loss at the same time (see CustomDataParallel and NetLoss)
-                losses = net(datum)
-                
-                losses = { k: (v).mean() for k,v in losses.items() } # Mean here because Dataparallel
-                loss = sum([losses[k] for k in losses])
-                
+
+                with amp.autocast(enabled=half_precision):
+                    # Forward Pass + Compute loss at the same time (see CustomDataParallel and NetLoss)
+                    losses = net(datum)
+                    losses = { k: (v).mean() for k,v in losses.items() } # Mean here because Dataparallel
+                    loss = sum([losses[k] for k in losses])
+
                 # no_inf_mean removes some components from the loss, so make sure to backward through all of it
                 # all_loss = sum([v.mean() for v in losses.values()])
 
                 # Backprop
-                loss.backward() # Do this to free up vram even if loss is not finite
+                scaler.scale(loss).backward() # Do this to free up vram even if loss is not finite
                 if torch.isfinite(loss).item():
-                    optimizer.step()
-                
+                    scaler.step(optimizer)
+                    scaler.update()
+                    optimizer.zero_grad()
+
                 # Add the loss to the moving average for bookkeeping
                 for k in losses:
                     loss_avgs[k].add(losses[k].item())
@@ -330,11 +395,16 @@ def train():
                     time_avg.add(elapsed)
 
                 if iteration % 10 == 0:
-                    eta_str = str(datetime.timedelta(seconds=(cfg.max_iter-iteration) * time_avg.get_avg())).split('.')[0]
-                    
+                    remaining_epoch_iterations = len(data_loader) - (iteration % len(data_loader))
+                    remaining_complete_epochs = (num_epochs - epoch - 1)
+                    remaining_iterations = remaining_epoch_iterations + remaining_complete_epochs * len(data_loader)
+                    eta_current_setup = datetime.timedelta(seconds=((remaining_iterations * time_avg.get_avg())))
+                    eta_max = datetime.timedelta(seconds=((max_steps - iteration) * time_avg.get_avg()))
+
+                    eta_str = str(min(eta_current_setup, eta_max)).split('.')[0]
                     total = sum([loss_avgs[k].get_avg() for k in losses])
                     loss_labels = sum([[k, loss_avgs[k].get_avg()] for k in loss_types if k in losses], [])
-                    
+
                     print(('[%3d] %7d ||' + (' %s: %.3f |' * len(losses)) + ' T: %.3f || ETA: %s || timer: %.3f')
                             % tuple([epoch, iteration] + loss_labels + [total, eta_str, elapsed]), flush=True)
 
@@ -345,12 +415,12 @@ def train():
 
                     if args.log_gpu:
                         log.log_gpu_stats = (iteration % 10 == 0) # nvidia-smi is sloooow
-                        
+
                     log.log('train', loss=loss_info, epoch=epoch, iter=iteration,
                         lr=round(cur_lr, 10), elapsed=elapsed)
 
                     log.log_gpu_stats = args.log_gpu
-                
+
                 iteration += 1
 
                 if iteration % args.save_interval == 0 and iteration != args.start_iter:
@@ -358,7 +428,10 @@ def train():
                         latest = SavePath.get_latest(args.save_folder, cfg.name)
 
                     print('Saving state, iter:', iteration)
-                    yolact_net.save_weights(save_path(epoch, iteration))
+                    yolact_net.save_checkpoint(
+                        save_path(epoch, iteration),
+                        recipe=sparseml_wrapper.state_dict().get('recipe'),
+                        epoch=epoch)
 
                     if args.keep_latest and latest is not None:
                         if args.keep_latest_interval <= 0 or iteration % args.keep_latest_interval != args.save_interval:
@@ -369,9 +442,8 @@ def train():
             if args.validation_epoch > 0:
                 if epoch % args.validation_epoch == 0 and epoch > 0:
                     compute_validation_map(epoch, iteration, yolact_net, val_dataset, log if args.log else None)
-        
-        # Compute validation mAP after training is finished
-        compute_validation_map(epoch, iteration, yolact_net, val_dataset, log if args.log else None)
+
+
     except KeyboardInterrupt:
         if args.interrupt:
             print('Stopping early. Saving network...')
@@ -379,10 +451,23 @@ def train():
             # Delete previous copy of the interrupted network so we don't spam the weights folder
             SavePath.remove_interrupt(args.save_folder)
             
-            yolact_net.save_weights(save_path(epoch, repr(iteration) + '_interrupt'))
+            yolact_net.save_checkpoint(
+                save_path(epoch, repr(iteration) +'_interrupt'),
+                recipe=sparseml_wrapper.state_dict().get('recipe'),
+                epoch=epoch,
+            )
         exit()
 
-    yolact_net.save_weights(save_path(epoch, iteration))
+    yolact_net.save_checkpoint(
+        save_path(epoch, iteration),
+        recipe=sparseml_wrapper.state_dict().get('recipe'),
+        epoch=epoch,
+    )
+    # Compute validation mAP after training is finished
+    print("Computing val mAP after training:")
+    compute_validation_map(epoch, iteration, yolact_net, val_dataset,
+                           log if args.log else None)
+
 
 
 def set_lr(optimizer, new_lr):

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -1,0 +1,95 @@
+import math
+
+import torch.nn as nn
+from sparseml.pytorch.optim import ScheduledModifierManager
+from sparseml.pytorch.utils import SparsificationGroupLogger
+
+
+def is_parallel(model):
+    return type(model) in (
+    nn.parallel.DataParallel, nn.parallel.DistributedDataParallel)
+
+
+class SparseMLWrapper(object):
+    def __init__(self, model, recipe):
+        self.enabled = bool(recipe)
+        self.model = model.module if is_parallel(model) else model
+        self.recipe = recipe
+        self.manager = ScheduledModifierManager.from_yaml(
+            recipe
+            ) if self.enabled else None
+        self.logger = None
+
+    def state_dict(self):
+        return {
+            'recipe': str(self.manager) if self.enabled else None,
+        }
+
+    def apply(self):
+        if self.enabled:
+            self.manager.apply(self.model)
+
+    def initialize(self, start_epoch):
+        if self.enabled:
+            self.manager.initialize(self.model, start_epoch)
+
+    def initialize_loggers(self, logger, tb_writer, wandb_logger, rank):
+        self.logger = logger
+
+        if self.enabled and rank in [-1, 0]:
+            self.manager.initialize_loggers(
+                [
+                    SparsificationGroupLogger(
+                        tensorboard=tb_writer,
+                        wandb_={'project': 'yolact'} if wandb_logger else None
+
+                    ),
+
+                ]
+            )
+
+    def modify(self, scaler, optimizer, model, dataloader):
+        if self.enabled:
+            return self.manager.modify(
+                model,
+                optimizer,
+                steps_per_epoch=len(dataloader),
+                wrap_optim=scaler
+            )
+
+        return scaler
+
+    def check_lr_override(self, scheduler):
+        # Override lr scheduler if recipe makes any LR updates
+        if self.should_override_scheduler():
+            self.logger.info(
+                'Disabling LR scheduler, managing LR using SparseML recipe'
+                )
+            scheduler = None
+
+        return scheduler
+
+    def should_override_scheduler(self):
+        return self.enabled and self.manager.learning_rate_modifiers
+
+    def check_epoch_override(self, epochs):
+        # Override num epochs if recipe explicitly modifies epoch range
+        if self.enabled and self.manager.epoch_modifiers and \
+                self.manager.max_epochs:
+            epochs = self.manager.max_epochs or epochs  # override num_epochs
+            self.logger.info(
+                f'Overriding number of epochs from SparseML manager to {epochs}'
+                )
+
+        return epochs
+
+    def qat_active(self, epoch):
+        if self.enabled and self.manager.quantization_modifiers:
+            qat_start = min(
+                [mod.start_epoch for mod in self.manager.quantization_modifiers]
+                )
+
+            return qat_start < epoch + 1
+
+        return False
+

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -69,6 +69,12 @@ class SparseMLWrapper(object):
                 file.write(str(self.manager))
             wandb.log_artifact(artifact)
 
+    def log_losses_wandb(self, losses=None):
+        if wandb_available:
+            wandb.log(
+                {'losses': losses}
+            )
+
     def modify(self, scaler, optimizer, model, dataloader):
         if self.enabled:
             return self.manager.modify(

--- a/utils/zoo.py
+++ b/utils/zoo.py
@@ -1,0 +1,48 @@
+from sparsezoo import Zoo
+
+
+def is_valid_stub(stub: str) -> bool:
+    return stub.startswith('zoo:')
+
+
+def _get_model_framework_file(model, path: str):
+    transfer_request = 'recipe_type=transfer' in path
+    checkpoint_available = any(
+        file.checkpoint for file in model.framework_files
+        )
+    final_available = any(
+        not file.checkpoint for file in model.framework_files
+        )
+
+    if transfer_request and checkpoint_available:
+        # checkpoints are saved for transfer learning use cases,
+        # return checkpoint if avaiable and requested
+        return [file for file in model.framework_files if file.checkpoint][0]
+
+    elif final_available:
+        # default to returning final state, if available
+        return [file for file in model.framework_files if not
+        file.checkpoint][0]
+
+    raise ValueError(f"Could not find a valid framework file for {path}")
+
+
+def download_checkpoint_from_stub(stub: str) -> str:
+    """
+    Helper to download a model checkpoint from SparseZoo Stub
+
+    NOTE: model and checkpoint are used interchangeably
+
+    :param stub: A valid SparseZoo Stub
+    :raises: ValueError if invalid stub given
+    :return: path to model checkpoint (after downloading from SparseZoo)
+    """
+
+    if is_valid_stub(stub=stub):
+        model = Zoo.load_model_from_stub(stub=stub)
+        file = _get_model_framework_file(model, stub)
+        path = file.downloaded_path()
+        return path
+
+    raise ValueError("Invalid Stub, Check for typo!!!")
+

--- a/yolact.py
+++ b/yolact.py
@@ -514,7 +514,8 @@ class Yolact(nn.Module):
 
                 loaded = True
             sparseml_wrapper.initialize(start_epoch=epoch or 0 if resume else 0)
-        if not loaded: self.load_state_dict(state_dict=state_dict)
+        if not loaded:
+            self.load_state_dict(state_dict=state_dict)
         return epoch or 0, recipe, sparseml_wrapper
 
     def init_weights(self, backbone_path):

--- a/yolact.py
+++ b/yolact.py
@@ -24,9 +24,9 @@ from utils.sparse import SparseMLWrapper
 torch.cuda.current_device()
 
 # As of March 10, 2019, Pytorch DataParallel still doesn't support JIT Script Modules
+# jit turned off for SparseMl Integration to support Quantization
 use_jit = False
-if not use_jit:
-    print('JIT turned off')
+
 
 ScriptModuleWrapper = torch.jit.ScriptModule if use_jit else nn.Module
 script_method_wrapper = torch.jit.script_method if use_jit else lambda fn, _rcn=None: fn
@@ -481,7 +481,7 @@ class Yolact(nn.Module):
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, recipe=None) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(self, path, recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
         :return: A tuple containing the epoch and the recipe if
@@ -513,7 +513,7 @@ class Yolact(nn.Module):
                 self.load_state_dict(state_dict)
 
                 loaded = True
-            sparseml_wrapper.initialize(start_epoch=epoch)
+            sparseml_wrapper.initialize(start_epoch=epoch or 0 if resume else 0)
         if not loaded: self.load_state_dict(state_dict=state_dict)
         return epoch or 0, recipe, sparseml_wrapper
 

--- a/yolact.py
+++ b/yolact.py
@@ -5,7 +5,7 @@ from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
 from math import sqrt
-from typing import List
+from typing import List, Optional, Tuple
 from collections import defaultdict
 
 from data.config import cfg, mask_type
@@ -19,12 +19,14 @@ from utils.functions import MovingAverage, make_net
 
 # This is required for Pytorch 1.0.1 on Windows to initialize Cuda on some driver versions.
 # See the bug report here: https://github.com/pytorch/pytorch/issues/17108
+from utils.sparse import SparseMLWrapper
+
 torch.cuda.current_device()
 
 # As of March 10, 2019, Pytorch DataParallel still doesn't support JIT Script Modules
-use_jit = torch.cuda.device_count() <= 1
+use_jit = False
 if not use_jit:
-    print('Multiple GPUs detected! Turning off JIT.')
+    print('JIT turned off')
 
 ScriptModuleWrapper = torch.jit.ScriptModule if use_jit else nn.Module
 script_method_wrapper = torch.jit.script_method if use_jit else lambda fn, _rcn=None: fn
@@ -37,7 +39,7 @@ class Concat(nn.Module):
 
         self.nets = nn.ModuleList(nets)
         self.extra_params = extra_params
-    
+
     def forward(self, x):
         # Concat each along the channel dimension
         return torch.cat([net(x) for net in self.nets], dim=1, **self.extra_params)
@@ -69,7 +71,7 @@ class PredictionModule(nn.Module):
         - parent:        If parent is a PredictionModule, this module will use all the layers
                          from parent instead of from this module.
     """
-    
+
     def __init__(self, in_channels, out_channels=1024, aspect_ratios=[[1]], scales=[1], parent=None, index=0):
         super().__init__()
 
@@ -85,7 +87,7 @@ class PredictionModule(nn.Module):
 
         if cfg.mask_proto_prototypes_as_features:
             in_channels += self.mask_dim
-        
+
         if parent is None:
             if cfg.extra_head_net is None:
                 out_channels = in_channels
@@ -100,13 +102,13 @@ class PredictionModule(nn.Module):
             self.bbox_layer = nn.Conv2d(out_channels, self.num_priors * 4,                **cfg.head_layer_params)
             self.conf_layer = nn.Conv2d(out_channels, self.num_priors * self.num_classes, **cfg.head_layer_params)
             self.mask_layer = nn.Conv2d(out_channels, self.num_priors * self.mask_dim,    **cfg.head_layer_params)
-            
+
             if cfg.use_mask_scoring:
                 self.score_layer = nn.Conv2d(out_channels, self.num_priors, **cfg.head_layer_params)
 
             if cfg.use_instance_coeff:
                 self.inst_layer = nn.Conv2d(out_channels, self.num_priors * cfg.num_instance_coeffs, **cfg.head_layer_params)
-            
+
             # What is this ugly lambda doing in the middle of all this clean prediction module code?
             def make_extra(num_layers):
                 if num_layers == 0:
@@ -119,7 +121,7 @@ class PredictionModule(nn.Module):
                     ] for _ in range(num_layers)], []))
 
             self.bbox_extra, self.conf_extra, self.mask_extra = [make_extra(x) for x in cfg.extra_layers]
-            
+
             if cfg.mask_type == mask_type.lincomb and cfg.mask_proto_coeff_gate:
                 self.gate_layer = nn.Conv2d(out_channels, self.num_priors * self.mask_dim, kernel_size=3, padding=1)
 
@@ -144,21 +146,21 @@ class PredictionModule(nn.Module):
         """
         # In case we want to use another module's layers
         src = self if self.parent[0] is None else self.parent[0]
-        
+
         conv_h = x.size(2)
         conv_w = x.size(3)
-        
+
         if cfg.extra_head_net is not None:
             x = src.upfeature(x)
-        
+
         if cfg.use_prediction_module:
             # The two branches of PM design (c)
             a = src.block(x)
-            
+
             b = src.conv(x)
             b = src.bn(b)
             b = F.relu(b)
-            
+
             # TODO: Possibly switch this out for a product
             x = a + b
 
@@ -168,7 +170,7 @@ class PredictionModule(nn.Module):
 
         bbox = src.bbox_layer(bbox_x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, 4)
         conf = src.conf_layer(conf_x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, self.num_classes)
-        
+
         if cfg.eval_mask_branch:
             mask = src.mask_layer(mask_x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, self.mask_dim)
         else:
@@ -178,7 +180,7 @@ class PredictionModule(nn.Module):
             score = src.score_layer(x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, 1)
 
         if cfg.use_instance_coeff:
-            inst = src.inst_layer(x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, cfg.num_instance_coeffs)    
+            inst = src.inst_layer(x).permute(0, 2, 3, 1).contiguous().view(x.size(0), -1, cfg.num_instance_coeffs)
 
         # See box_utils.decode for an explanation of this
         if cfg.use_yolo_regressors:
@@ -198,7 +200,7 @@ class PredictionModule(nn.Module):
 
         if cfg.mask_proto_split_prototypes_by_head and cfg.mask_type == mask_type.lincomb:
             mask = F.pad(mask, (self.index * self.mask_dim, (self.num_heads - self.index - 1) * self.mask_dim), mode='constant', value=0)
-        
+
         priors = self.make_priors(conv_h, conv_w, x.device)
 
         preds = { 'loc': bbox, 'conf': conf, 'mask': mask, 'priors': priors }
@@ -208,7 +210,7 @@ class PredictionModule(nn.Module):
 
         if cfg.use_instance_coeff:
             preds['inst'] = inst
-        
+
         return preds
 
     def make_priors(self, conv_h, conv_w, device):
@@ -225,7 +227,7 @@ class PredictionModule(nn.Module):
                     # +0.5 because priors are in center-size notation
                     x = (i + 0.5) / conv_w
                     y = (j + 0.5) / conv_h
-                    
+
                     for ars in self.aspect_ratios:
                         for scale in self.scales:
                             for ar in ars:
@@ -238,7 +240,7 @@ class PredictionModule(nn.Module):
                                 else:
                                     w = scale * ar / conv_w
                                     h = scale / ar / conv_h
-                                
+
                                 # This is for backward compatability with a bug where I made everything square by accident
                                 if cfg.backbone.use_square_anchors:
                                     h = w
@@ -254,12 +256,12 @@ class PredictionModule(nn.Module):
                 # This whole weird situation is so that DataParalell doesn't copy the priors each iteration
                 if prior_cache[size] is None:
                     prior_cache[size] = {}
-                
+
                 if device not in prior_cache[size]:
                     prior_cache[size][device] = self.priors.to(device)
 
                 self.priors = prior_cache[size][device]
-        
+
         return self.priors
 
 class FPN(ScriptModuleWrapper):
@@ -300,7 +302,7 @@ class FPN(ScriptModuleWrapper):
                 nn.Conv2d(cfg.fpn.num_features, cfg.fpn.num_features, kernel_size=3, padding=1, stride=2)
                 for _ in range(cfg.fpn.num_downsample)
             ])
-        
+
         self.interpolation_mode     = cfg.fpn.interpolation_mode
         self.num_downsample         = cfg.fpn.num_downsample
         self.use_conv_downsample    = cfg.fpn.use_conv_downsample
@@ -330,10 +332,10 @@ class FPN(ScriptModuleWrapper):
             if j < len(convouts) - 1:
                 _, _, h, w = convouts[j].size()
                 x = F.interpolate(x, size=(h, w), mode=self.interpolation_mode, align_corners=False)
-            
+
             x = x + lat_layer(convouts[j])
             out[j] = x
-        
+
         # This janky second loop is here because TorchScript.
         j = len(convouts)
         for pred_layer in self.pred_layers:
@@ -400,7 +402,7 @@ class Yolact(nn.Module):
         super().__init__()
 
         self.backbone = construct_backbone(cfg.backbone)
-
+        self.export = False # to support onnx exports
         if cfg.freeze_bn:
             self.freeze_bn()
 
@@ -415,7 +417,7 @@ class Yolact(nn.Module):
                 self.num_grids = 0
 
             self.proto_src = cfg.mask_proto_src
-            
+
             if self.proto_src is None: in_channels = 3
             elif cfg.fpn is not None: in_channels = cfg.fpn.num_features
             else: in_channels = self.backbone.channels[self.proto_src]
@@ -462,7 +464,7 @@ class Yolact(nn.Module):
             # This comes from the smallest layer selected
             # Also note that cfg.num_classes includes background
             self.class_existence_fc = nn.Linear(src_channels[-1], cfg.num_classes - 1)
-        
+
         if cfg.use_semantic_segmentation_loss:
             self.semantic_seg_conv = nn.Conv2d(src_channels[0], cfg.num_classes-1, kernel_size=1)
 
@@ -470,24 +472,50 @@ class Yolact(nn.Module):
         self.detect = Detect(cfg.num_classes, bkg_label=0, top_k=cfg.nms_top_k,
             conf_thresh=cfg.nms_conf_thresh, nms_thresh=cfg.nms_thresh)
 
-    def save_weights(self, path):
+    def save_checkpoint(self, path, recipe=None, epoch=0):
         """ Saves the model's weights using compression because the file sizes were getting too big. """
-        torch.save(self.state_dict(), path)
-    
-    def load_weights(self, path):
-        """ Loads weights from a compressed save file. """
-        state_dict = torch.load(path)
+        checkpoint = {
+                         'epoch': epoch,
+                         'model_state_dict': self.state_dict(),
+                         'recipe': recipe,
+                     }
+        torch.save(checkpoint, path)
+
+    def load_checkpoint(self, path, recipe=None) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+        """ Loads weights into the current Yolact object.
+
+        :return: A tuple containing the epoch and the recipe if
+            found in the checkpoint, and a SparseML Wrapper instance
+        """
+
+        checkpoint = torch.load(path)
+        epoch = checkpoint.get('epoch')
+        recipe = recipe or checkpoint.get('recipe')
+        state_dict = checkpoint.get('model_state_dict', checkpoint)
+        sparseml_wrapper = SparseMLWrapper(self, recipe)
 
         # For backward compatability, remove these (the new variable is called layers)
         for key in list(state_dict.keys()):
             if key.startswith('backbone.layer') and not key.startswith('backbone.layers'):
                 del state_dict[key]
-        
+
             # Also for backward compatibility with v1.0 weights, do this check
             if key.startswith('fpn.downsample_layers.'):
                 if cfg.fpn is not None and int(key.split('.')[2]) >= cfg.fpn.num_downsample:
                     del state_dict[key]
-        self.load_state_dict(state_dict)
+
+        loaded = False
+        if self.export:
+            sparseml_wrapper.apply()
+        else:
+            quantized_state_dict = any([name.endswith('.zero_point') for name in state_dict.keys()])
+            if not quantized_state_dict:
+                self.load_state_dict(state_dict)
+
+                loaded = True
+            sparseml_wrapper.initialize(start_epoch=epoch)
+        if not loaded: self.load_state_dict(state_dict=state_dict)
+        return epoch or 0, recipe, sparseml_wrapper
 
     def init_weights(self, backbone_path):
         """ Initialize weights for training. """
@@ -495,7 +523,7 @@ class Yolact(nn.Module):
         self.backbone.init_backbone(backbone_path)
 
         conv_constants = getattr(nn.Conv2d(1, 1, 1), '__constants__')
-        
+
         # Quick lambda to test if one list contains the other
         def all_in(x, y):
             for _x in x:
@@ -519,7 +547,7 @@ class Yolact(nn.Module):
                     is_script_conv = (
                         all_in(module.__dict__['_constants_set'], conv_constants)
                         and all_in(conv_constants, module.__dict__['_constants_set']))
-            
+
             is_conv_layer = isinstance(module, nn.Conv2d) or is_script_conv
 
             if is_conv_layer and module not in self.backbone.backbone_modules:
@@ -545,7 +573,7 @@ class Yolact(nn.Module):
                             module.bias.data[1:] = -np.log((1 - cfg.focal_loss_init_pi) / cfg.focal_loss_init_pi)
                     else:
                         module.bias.data.zero_()
-    
+
     def train(self, mode=True):
         super().train(mode)
 
@@ -560,13 +588,13 @@ class Yolact(nn.Module):
 
                 module.weight.requires_grad = enable
                 module.bias.requires_grad = enable
-    
+
     def forward(self, x):
         """ The input should be of size [batch_size, 3, img_h, img_w] """
         _, _, img_h, img_w = x.size()
         cfg._tmp_img_h = img_h
         cfg._tmp_img_w = img_w
-        
+
         with timer.env('backbone'):
             outs = self.backbone(x)
 
@@ -580,7 +608,7 @@ class Yolact(nn.Module):
         if cfg.mask_type == mask_type.lincomb and cfg.eval_mask_branch:
             with timer.env('proto'):
                 proto_x = x if self.proto_src is None else outs[self.proto_src]
-                
+
                 if self.num_grids > 0:
                     grids = self.grid.repeat(proto_x.size(0), 1, 1, 1)
                     proto_x = torch.cat([proto_x, grids], dim=1)
@@ -594,7 +622,7 @@ class Yolact(nn.Module):
 
                     if cfg.mask_proto_prototypes_as_features_no_grad:
                         proto_downsampled = proto_out.detach()
-                
+
                 # Move the features last so the multiplication is easy
                 proto_out = proto_out.permute(0, 2, 3, 1).contiguous()
 
@@ -612,7 +640,7 @@ class Yolact(nn.Module):
 
             if cfg.use_instance_coeff:
                 pred_outs['inst'] = []
-            
+
             for idx, pred_layer in zip(self.selected_layers, self.prediction_layers):
                 pred_x = outs[idx]
 
@@ -626,7 +654,7 @@ class Yolact(nn.Module):
                     pred_layer.parent = [self.prediction_layers[0]]
 
                 p = pred_layer(pred_x)
-                
+
                 for k, v in p.items():
                     pred_outs[k].append(v)
 
@@ -666,13 +694,15 @@ class Yolact(nn.Module):
 
                 if cfg.use_objectness_score:
                     objectness = torch.sigmoid(pred_outs['conf'][:, :, 0])
-                    
+
                     pred_outs['conf'][:, :, 1:] = (objectness > 0.10)[..., None] \
                         * F.softmax(pred_outs['conf'][:, :, 1:], dim=-1)
-                    
+
                 else:
                     pred_outs['conf'] = F.softmax(pred_outs['conf'], -1)
 
+            if self.export:
+                return pred_outs
             return self.detect(pred_outs, self)
 
 
@@ -707,7 +737,7 @@ if __name__ == '__main__':
     for k, a in y.items():
         print(k + ': ', a.size(), torch.sum(a))
     exit()
-    
+
     net(x)
     # timer.disable('pass2')
     avg = MovingAverage()


### PR DESCRIPTION
- Adds recipe and ckpt arguments
- Supports SparseZoo Stubs
- Supports resuming training from a previous SparseML checkpoint
- The checkpoint can be Quantized or Pruned
- Supports overriding checkpoint epoch
- Adds a export member variable to Yolact script for supporting export flows
- Adds support for weights and biases
- Adds Saving logic before mAp Calculation
- Turns off JIT