### PR TITLE
Update: requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ cython
 opencv-python
 pycocotools
 matplotlib
-sparseml[torchvision] >= 0.7.0
+sparseml
+torchvision<=0.8.2


### PR DESCRIPTION
- Pinned `torchvision` version to `<= 0.8.2` (will also install `torch <=1.7.1`)
On account of breaking changes for `set_default_tensor` in `train.py` `line 124`
with `torch 1.9.0`