### PR TITLE
Fixes: for stubs; cleanup;

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -131,6 +131,9 @@ Example usage:
 ##########
 # Commands to Evaluate on COCO Validation
 # Needs Data to be set up using `sh data/scripts/COCO.sh`
+# Needs DeepSparse installed for running with deepsparse `pip install deepsparse`
+# Needs ORT installed for running with onnxruntime `pip install onnxruntime`
+
 
 1) # Using DeepSparse Engine with local weights
 # python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS

--- a/eval.py
+++ b/eval.py
@@ -1,8 +1,235 @@
-import contextlib
-import itertools
+"""
+Eval script to annotate/evaluate and benchmark YOLACT models using DeepSparse,
+Onnx-Runtime or PyTorch Engines
 
+####################
+usage: eval.py [-h] [--trained_model TRAINED_MODEL] [--top_k TOP_K]
+               [--cuda CUDA] [--fast_nms FAST_NMS]
+               [--cross_class_nms CROSS_CLASS_NMS]
+               [--display_masks DISPLAY_MASKS]
+               [--display_bboxes DISPLAY_BBOXES] [--display_text DISPLAY_TEXT]
+               [--display_scores DISPLAY_SCORES] [--display] [--shuffle]
+               [--ap_data_file AP_DATA_FILE] [--resume]
+               [--max_images MAX_IMAGES] [--output_coco_json]
+               [--bbox_det_file BBOX_DET_FILE] [--mask_det_file MASK_DET_FILE]
+               [--config CONFIG] [--output_web_json]
+               [--web_det_path WEB_DET_PATH] [--no_bar]
+               [--display_lincomb DISPLAY_LINCOMB] [--benchmark] [--no_sort]
+               [--seed SEED] [--mask_proto_debug] [--no_crop] [--image IMAGE]
+               [--images IMAGES] [--video VIDEO]
+               [--video_multiframe VIDEO_MULTIFRAME]
+               [--score_threshold SCORE_THRESHOLD] [--dataset DATASET]
+               [--detect] [--display_fps] [--emulate_playback]
+               [--num_cores NUM_CORES]
+               [--warm_up_iterations WARM_UP_ITERATIONS]
+               [--num_iterations NUM_ITERATIONS] [--batch_size BATCH_SIZE]
+               [--engine {deepsparse,ort,torch}]
+
+YOLACT COCO Evaluation
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --trained_model TRAINED_MODEL
+                        Trained state_dict file path to open. If "interrupt",
+                        this will open the interrupt file.
+  --top_k TOP_K         Further restrict the number of predictions to parse
+  --cuda CUDA           Use cuda to evaulate model
+  --fast_nms FAST_NMS   Whether to use a faster, but not entirely correct
+                        version of NMS.
+  --cross_class_nms CROSS_CLASS_NMS
+                        Whether compute NMS cross-class or per-class.
+  --display_masks DISPLAY_MASKS
+                        Whether or not to display masks over bounding boxes
+  --display_bboxes DISPLAY_BBOXES
+                        Whether or not to display bboxes around masks
+  --display_text DISPLAY_TEXT
+                        Whether or not to display text (class [score])
+  --display_scores DISPLAY_SCORES
+                        Whether or not to display scores in addition to
+                        classes
+  --display             Display qualitative results instead of quantitative
+                        ones.
+  --shuffle             Shuffles the images when displaying them. Doesn't have
+                        much of an effect when display is off though.
+  --ap_data_file AP_DATA_FILE
+                        In quantitative mode, the file to save detections
+                        before calculating mAP.
+  --resume              If display not set, this resumes mAP calculations from
+                        the ap_data_file.
+  --max_images MAX_IMAGES
+                        The maximum number of images from the dataset to
+                        consider. Use -1 for all.
+  --output_coco_json    If display is not set, instead of processing IoU
+                        values, this just dumps detections into the coco json
+                        file.
+  --bbox_det_file BBOX_DET_FILE
+                        The output file for coco bbox results if
+                        --coco_results is set.
+  --mask_det_file MASK_DET_FILE
+                        The output file for coco mask results if
+                        --coco_results is set.
+  --config CONFIG       The config object to use.
+  --output_web_json     If display is not set, instead of processing IoU
+                        values, this dumps detections for usage with the
+                        detections viewer web thingy.
+  --web_det_path WEB_DET_PATH
+                        If output_web_json is set, this is the path to dump
+                        detections into.
+  --no_bar              Do not output the status bar. This is useful for when
+                        piping to a file.
+  --display_lincomb DISPLAY_LINCOMB
+                        If the config uses lincomb masks, output a
+                        visualization of how those masks are created.
+  --benchmark           Equivalent to running display mode but without
+                        displaying an image.
+  --no_sort             Do not sort images by hashed image ID.
+  --seed SEED           The seed to pass into random.seed. Note: this is only
+                        really for the shuffle and does not (I think) affect
+                        cuda stuff.
+  --mask_proto_debug    Outputs stuff for scripts/compute_mask.py.
+  --no_crop             Do not crop output masks with the predicted bounding
+                        box.
+  --image IMAGE         A path to an image to use for display.
+  --images IMAGES       An input folder of images and output folder to save
+                        detected images. Should be in the format
+                        input->output.
+  --video VIDEO         A path to a video to evaluate on. Passing in a number
+                        will use that index webcam.
+  --video_multiframe VIDEO_MULTIFRAME
+                        The number of frames to evaluate in parallel to make
+                        videos play at higher fps.
+  --score_threshold SCORE_THRESHOLD
+                        Detections with a score under this threshold will not
+                        be considered. This currently only works in display
+                        mode.
+  --dataset DATASET     If specified, override the dataset specified in the
+                        config with this one (example: coco2017_dataset).
+  --detect              Don't evauluate the mask branch at all and only do
+                        object detection. This only works for --display and
+                        --benchmark.
+  --display_fps         When displaying / saving video, draw the FPS on the
+                        frame
+  --emulate_playback    When saving a video, emulate the framerate that you'd
+                        get running in real-time mode.
+  --num_cores NUM_CORES
+                        The num of cores to use (supported only with
+                        deepsparse), defaults to None
+  --warm_up_iterations WARM_UP_ITERATIONS
+                        The num of warm up iterations to run the engine for,
+                        defaults to 1
+  --num_iterations NUM_ITERATIONS
+                        The num of iterations to run the engine for, defaults
+                        to the validation set
+  --batch_size BATCH_SIZE
+                        The batch size to use the engine for, defaults to 1
+  --engine {deepsparse,ort,torch}
+                        Engine to use for evaluation choices are
+                        ['deepsparse', 'ort', 'torch']
+####################
+Example usage:
+
+##########
+# Commands to Evaluate on COCO Validation
+# Needs Data to be set up using `sh data/scripts/COCO.sh`
+
+1) # Using DeepSparse Engine with local weights
+# python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS
+
+python eval.py --trained_model weights/model.onnx
+
+2) # Using DeepSparse Engine with SparseZoo stubs
+# Downloads weights automatically from SparseZoo
+# python eval.py --trained_model SPARSEZOO_YOLACT_STUB
+
+python eval.py \
+--trained_model \
+'zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none'
+
+3) # Using ORT Engine with local weights
+# python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS --engine ort
+
+python eval.py --trained_model weights/model.onnx --engine ort
+
+4) # Using ORT Engine with SparseZoo stubs
+# Downloads weights automatically from SparseZoo
+# python eval.py --trained_model SPARSEZOO_YOLACT_STUB --engine ort
+
+python eval.py \
+--trained_model \
+'zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none' \
+--engine ort
+
+5) # Using TORCH with local weights
+# python eval.py --trained_model PRETRAINED_TORCH_WEIGHTS
+
+python eval.py --trained_model weights/model.pth
+
+6) # Using TORCH Engine with SparseZoo stubs
+# Downloads weights automatically from SparseZoo
+# python eval.py --trained_model SPARSEZOO_YOLACT_STUB --engine torch
+
+python eval.py \
+--trained_model \
+'zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none' \
+--engine torch
+
+##########
+# Commands to ANNOTATE using a PRETRAINED MODEL and DeepSparse
+# --trained_model can be replaced with any valid YOLACT SparseZoo stub
+
+1) # Annotate an Image using DeepSparse
+# python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS \
+# --image input.png:output.png
+
+python eval.py --trained_model weights/model.onnx \
+--image data/yolact_example_0.png:data/yolact_example_out_0.png
+
+2) # Annotate Images using DeepSparse
+# python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS \
+--images input_dir:output_dir --score SCORE_THRESHOLD
+
+python eval.py --trained_model weights/model.onnx \
+--images input_dir:output_dir --score 0.6
+
+3) # Annotate Video using DeepSparse
+# python eval.py --trained_model PRETRAINED_ONNX_WEIGHTS \
+--video input.mp4:output.mp4 --score 0.6
+
+python eval.py --trained_model weights/model.onnx \
+--video input.mp4:output.mp4 --score 0.6
+
+##########
+# Commands to benchmark using a PRETRAINED MODEL on COCO dataset
+# --trained_model can be replaced with any valid YOLACT SparseZoo stub
+# (Note: benchmarking on custom images, videos not supported yet; However
+a Custom Dataset is supported)
+
+1) # Using DeepSparse and the entire COCO validation set
+
+python eval.py --trained_model weights/model.onnx --score 0.6 --benchmark
+
+2) # Using DeepSparse on the COCO validation set for fixed num of iterations
+
+python eval.py --trained_model weights/model.onnx \
+--score 0.6 --benchmark --warm_up_iterations 10 \
+--num_iterations 100
+
+####################
+Some Useful Model Stubs:
+1) Base YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none
+2) Pruned YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none
+3) Pruned Quantized YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned82_quant-none
+
+"""
+import itertools
 from data import COCODetection, get_label_map, MEANS, COLORS
-from utils.wrapper import DeepsparseWrapper
+from utils.engines import Engine
+from utils.wrapper import DeepSparseWrapper, ORTWrapper
+from utils.zoo import get_checkpoint_from_stub, get_model_onnx_from_stub, \
+    is_valid_stub
 from yolact import Yolact
 from utils.augmentations import BaseTransform, FastBaseTransform, Resize
 from utils.functions import MovingAverage, ProgressBar
@@ -34,9 +261,6 @@ import matplotlib.pyplot as plt
 import cv2
 deepsparse_available = False
 device='cpu'
-with contextlib.suppress(Exception):
-    import deepsparse
-    deepsparse_available = True
 
 def str2bool(v):
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
@@ -47,10 +271,11 @@ def str2bool(v):
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
 def parse_args(argv=None):
+    base_model_stub = 'zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya' \
+                      '/coco/base-none'
     parser = argparse.ArgumentParser(
         description='YOLACT COCO Evaluation')
-    parser.add_argument('--trained_model',
-                        default='weights/ssd300_mAP_77.43_v2.pth', type=str,
+    parser.add_argument('--trained_model',default=base_model_stub, type=str,
                         help='Trained state_dict file path to open. If "interrupt", this will open the interrupt file.')
     parser.add_argument('--top_k', default=5, type=int,
                         help='Further restrict the number of predictions to parse')
@@ -84,7 +309,7 @@ def parse_args(argv=None):
                         help='The output file for coco bbox results if --coco_results is set.')
     parser.add_argument('--mask_det_file', default='results/mask_detections.json', type=str,
                         help='The output file for coco mask results if --coco_results is set.')
-    parser.add_argument('--config', default=None,
+    parser.add_argument('--config', default='yolact_darknet53_config',
                         help='The config object to use.')
     parser.add_argument('--output_web_json', dest='output_web_json', action='store_true',
                         help='If display is not set, instead of processing IoU values, this dumps detections for usage with the detections viewer web thingy.')
@@ -126,6 +351,7 @@ def parse_args(argv=None):
     parser.add_argument('--warm_up_iterations', default=1, type=int, help="The num of warm up iterations to run the engine for, defaults to 1")
     parser.add_argument('--num_iterations', default=0, type=int, help="The num of iterations to run the engine for, defaults to the validation set")
     parser.add_argument('--batch_size', default=1, type=int, help="The batch size to use the engine for, defaults to 1")
+    parser.add_argument('--engine', default=None, choices=Engine.supported(), help=f'Engine to use for evaluation choices are {Engine.supported()}')
 
     parser.set_defaults(no_bar=False, display=False, resume=False, output_coco_json=False, output_web_json=False, shuffle=False,
                         benchmark=False, no_sort=False, no_hash=False, mask_proto_debug=False, crop=True, detect=False, display_fps=False,
@@ -709,10 +935,11 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
 
     def transform_frame(frames):
         with torch.no_grad():
-            frames = []
-            for frame in frames:
-                f = torch.from_numpy(frame)
-                frames.append(f.cuda().float() if args.cuda else f.float())
+            frames = [
+                torch.from_numpy(frame).cuda().float() if args.cuda
+                else torch.from_numpy(frame).float()
+                for frame in frames
+            ]
             return frames, transform(torch.stack(frames, 0))
 
     def eval_network(inp):
@@ -915,7 +1142,6 @@ def evaluate(net:Yolact, dataset, train_mode=False):
 
     frame_times = MovingAverage()
     dataset_size = len(dataset) if args.max_images < 0 else min(args.max_images, len(dataset))
-    progress_bar = ProgressBar(30, dataset_size)
 
     print()
 
@@ -946,8 +1172,11 @@ def evaluate(net:Yolact, dataset, train_mode=False):
         hashed = [badhash(x) for x in dataset.ids]
         dataset_indices.sort(key=lambda x: hashed[x])
 
+    dataset_size = args.num_iterations or dataset_size
     dataset_indices = dataset_indices[:dataset_size]
     printed_fps_calc_message = False
+    progress_bar = ProgressBar(30, dataset_size)
+
     try:
         # Main eval loop
         for it, image_idx in enumerate(itertools.cycle(dataset_indices)):
@@ -986,13 +1215,16 @@ def evaluate(net:Yolact, dataset, train_mode=False):
                 plt.title(str(dataset.ids[image_idx]))
                 plt.show()
             elif not args.no_bar:
-                if it > args.warm_up_iterations: fps = 1 / frame_times.get_avg()
-                else: fps = 0
-                progress = (it+1) / dataset_size * 100
-                progress_bar.set_val(it+1)
+                if it > args.warm_up_iterations:
+                    fps = 1 / frame_times.get_avg()
+                else:
+                    fps = 0
+                curr_progress = it + 1 - args.warm_up_iterations
+                progress = curr_progress / dataset_size * 100
+                progress_bar.set_val(curr_progress)
                 if it > args.warm_up_iterations:
                     print('\rProcessing Images  %s %6d / %6d (%5.2f%%)    %5.2f fps        '
-                    % (repr(progress_bar), it+1, dataset_size, progress, fps), end='')
+                          % (repr(progress_bar), curr_progress, dataset_size, progress, fps), end='')
 
 
 
@@ -1014,8 +1246,6 @@ def evaluate(net:Yolact, dataset, train_mode=False):
         elif args.benchmark:
             print()
             print()
-            print('Stats for the last frame:')
-            timer.print_stats()
             avg_seconds = frame_times.get_avg()
             print('Average: %5.2f fps, %5.2f ms' % (1 / frame_times.get_avg(), 1000*avg_seconds))
 
@@ -1077,13 +1307,15 @@ def print_maps(all_maps):
     print(make_sep(len(all_maps['box']) + 1))
     print()
 
+def get_engine(model_filepath: str, engine=None):
+    return Engine.from_filepath(
+        filepath=model_filepath,
+        default_onnx=engine,
+    )
 
 
 if __name__ == '__main__':
     parse_args()
-    run_deepsparse = args.trained_model.endswith('.onnx') or args.trained_model.startswith('zoo')
-    if deepsparse_available and run_deepsparse:
-        args.cuda = False
     if args.config is not None:
         set_cfg(args.config)
 
@@ -1091,13 +1323,16 @@ if __name__ == '__main__':
         args.trained_model = SavePath.get_interrupt('weights/')
     elif args.trained_model == 'latest':
         args.trained_model = SavePath.get_latest('weights/', cfg.name)
+    elif is_valid_stub(args.trained_model):
+        if args.engine == 'torch':
+            args.trained_model = get_checkpoint_from_stub(args.trained_model)
+        else:
+            args.trained_model = get_model_onnx_from_stub(args.trained_model)
 
-    if args.config is None:
-        model_path = SavePath.from_str(args.trained_model)
-        # TODO: Bad practice? Probably want to do a name lookup instead.
-        args.config = model_path.model_name + '_config'
-        print('Config not specified. Parsed %s from the file name.\n' % args.config)
-        set_cfg(args.config)
+    args.engine = get_engine(
+        model_filepath=args.trained_model,
+        engine=args.engine,
+    )
 
     if args.detect:
         cfg.eval_mask_branch = False
@@ -1109,9 +1344,14 @@ if __name__ == '__main__':
         if not os.path.exists('results'):
             os.makedirs('results')
 
+        if args.engine in [Engine.DEEPSPARSE, Engine.ORT]:
+            args.cuda = False
+            device = 'cpu'
+
         if args.cuda:
             cudnn.fastest = True
             torch.set_default_tensor_type('torch.cuda.FloatTensor')
+            device = 'cuda'
         else:
             torch.set_default_tensor_type('torch.FloatTensor')
 
@@ -1130,17 +1370,14 @@ if __name__ == '__main__':
 
         print('Loading model...', end='')
 
-        if deepsparse_available and run_deepsparse:
-            net = DeepsparseWrapper(filepath=args.trained_model, cfg=cfg,
+        if args.engine == Engine.DEEPSPARSE:
+            net = DeepSparseWrapper(filepath=args.trained_model, cfg=cfg,
                                     num_cores=args.num_cores,
                                     batch_size=args.batch_size
                                     )
-
-            device = 'cpu'
+        elif args.engine == Engine.ORT:
+            net = ORTWrapper(filepath=args.trained_model, cfg=cfg)
         else:
-            if args.cuda:
-
-                device = 'cuda'
             net = Yolact()
             net.load_checkpoint(args.trained_model)
             net.eval()

--- a/eval.py
+++ b/eval.py
@@ -7,16 +7,17 @@ usage: eval.py [-h] [--trained_model TRAINED_MODEL] [--top_k TOP_K]
                [--cuda CUDA] [--fast_nms FAST_NMS]
                [--cross_class_nms CROSS_CLASS_NMS]
                [--display_masks DISPLAY_MASKS]
-               [--display_bboxes DISPLAY_BBOXES] [--display_text DISPLAY_TEXT]
+               [--display_bboxes DISPLAY_BBOXES]
+               [--display_text DISPLAY_TEXT]
                [--display_scores DISPLAY_SCORES] [--display] [--shuffle]
                [--ap_data_file AP_DATA_FILE] [--resume]
                [--max_images MAX_IMAGES] [--output_coco_json]
-               [--bbox_det_file BBOX_DET_FILE] [--mask_det_file MASK_DET_FILE]
-               [--config CONFIG] [--output_web_json]
-               [--web_det_path WEB_DET_PATH] [--no_bar]
-               [--display_lincomb DISPLAY_LINCOMB] [--benchmark] [--no_sort]
-               [--seed SEED] [--mask_proto_debug] [--no_crop] [--image IMAGE]
-               [--images IMAGES] [--video VIDEO]
+               [--bbox_det_file BBOX_DET_FILE]
+               [--mask_det_file MASK_DET_FILE] [--config CONFIG]
+               [--output_web_json] [--web_det_path WEB_DET_PATH] [--no_bar]
+               [--display_lincomb DISPLAY_LINCOMB] [--benchmark]
+               [--no_sort] [--seed SEED] [--mask_proto_debug] [--no_crop]
+               [--image IMAGE] [--images IMAGES] [--video VIDEO]
                [--video_multiframe VIDEO_MULTIFRAME]
                [--score_threshold SCORE_THRESHOLD] [--dataset DATASET]
                [--detect] [--display_fps] [--emulate_playback]
@@ -30,8 +31,10 @@ YOLACT COCO Evaluation
 optional arguments:
   -h, --help            show this help message and exit
   --trained_model TRAINED_MODEL
-                        Trained state_dict file path to open. If "interrupt",
-                        this will open the interrupt file.
+                        Trained state_dict file path to open. If
+                        "interrupt", this will open the interrupt
+                        file.Defaults to YOLACT base model stub from
+                        SparseZoo
   --top_k TOP_K         Further restrict the number of predictions to parse
   --cuda CUDA           Use cuda to evaulate model
   --fast_nms FAST_NMS   Whether to use a faster, but not entirely correct
@@ -49,59 +52,60 @@ optional arguments:
                         classes
   --display             Display qualitative results instead of quantitative
                         ones.
-  --shuffle             Shuffles the images when displaying them. Doesn't have
-                        much of an effect when display is off though.
+  --shuffle             Shuffles the images when displaying them. Doesn't
+                        have much of an effect when display is off though.
   --ap_data_file AP_DATA_FILE
                         In quantitative mode, the file to save detections
                         before calculating mAP.
-  --resume              If display not set, this resumes mAP calculations from
-                        the ap_data_file.
+  --resume              If display not set, this resumes mAP calculations
+                        from the ap_data_file.
   --max_images MAX_IMAGES
                         The maximum number of images from the dataset to
                         consider. Use -1 for all.
   --output_coco_json    If display is not set, instead of processing IoU
-                        values, this just dumps detections into the coco json
-                        file.
+                        values, this just dumps detections into the coco
+                        json file.
   --bbox_det_file BBOX_DET_FILE
                         The output file for coco bbox results if
                         --coco_results is set.
   --mask_det_file MASK_DET_FILE
                         The output file for coco mask results if
                         --coco_results is set.
-  --config CONFIG       The config object to use.
+  --config CONFIG       The config object to use. Defaults to
+                        yolact_darknet53_config (for DarkNet53 backbones).
   --output_web_json     If display is not set, instead of processing IoU
                         values, this dumps detections for usage with the
                         detections viewer web thingy.
   --web_det_path WEB_DET_PATH
                         If output_web_json is set, this is the path to dump
                         detections into.
-  --no_bar              Do not output the status bar. This is useful for when
-                        piping to a file.
+  --no_bar              Do not output the status bar. This is useful for
+                        when piping to a file.
   --display_lincomb DISPLAY_LINCOMB
                         If the config uses lincomb masks, output a
                         visualization of how those masks are created.
   --benchmark           Equivalent to running display mode but without
                         displaying an image.
   --no_sort             Do not sort images by hashed image ID.
-  --seed SEED           The seed to pass into random.seed. Note: this is only
-                        really for the shuffle and does not (I think) affect
-                        cuda stuff.
+  --seed SEED           The seed to pass into random.seed. Note: this is
+                        only really for the shuffle and does not (I think)
+                        affect cuda stuff.
   --mask_proto_debug    Outputs stuff for scripts/compute_mask.py.
-  --no_crop             Do not crop output masks with the predicted bounding
-                        box.
+  --no_crop             Do not crop output masks with the predicted
+                        bounding box.
   --image IMAGE         A path to an image to use for display.
   --images IMAGES       An input folder of images and output folder to save
                         detected images. Should be in the format
                         input->output.
-  --video VIDEO         A path to a video to evaluate on. Passing in a number
-                        will use that index webcam.
+  --video VIDEO         A path to a video to evaluate on. Passing in a
+                        number will use that index webcam.
   --video_multiframe VIDEO_MULTIFRAME
-                        The number of frames to evaluate in parallel to make
-                        videos play at higher fps.
+                        The number of frames to evaluate in parallel to
+                        make videos play at higher fps.
   --score_threshold SCORE_THRESHOLD
-                        Detections with a score under this threshold will not
-                        be considered. This currently only works in display
-                        mode.
+                        Detections with a score under this threshold will
+                        not be considered. This currently only works in
+                        display mode.
   --dataset DATASET     If specified, override the dataset specified in the
                         config with this one (example: coco2017_dataset).
   --detect              Don't evauluate the mask branch at all and only do
@@ -109,17 +113,17 @@ optional arguments:
                         --benchmark.
   --display_fps         When displaying / saving video, draw the FPS on the
                         frame
-  --emulate_playback    When saving a video, emulate the framerate that you'd
-                        get running in real-time mode.
+  --emulate_playback    When saving a video, emulate the framerate that
+                        you'd get running in real-time mode.
   --num_cores NUM_CORES
                         The num of cores to use (supported only with
                         deepsparse), defaults to None
   --warm_up_iterations WARM_UP_ITERATIONS
-                        The num of warm up iterations to run the engine for,
-                        defaults to 1
+                        The num of warm up iterations to run the engine
+                        for, defaults to 1
   --num_iterations NUM_ITERATIONS
-                        The num of iterations to run the engine for, defaults
-                        to the validation set
+                        The num of iterations to run the engine for,
+                        defaults to the validation set
   --batch_size BATCH_SIZE
                         The batch size to use the engine for, defaults to 1
   --engine {deepsparse,ort,torch}
@@ -279,7 +283,10 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         description='YOLACT COCO Evaluation')
     parser.add_argument('--trained_model',default=base_model_stub, type=str,
-                        help='Trained state_dict file path to open. If "interrupt", this will open the interrupt file.')
+                        help='Trained state_dict file path to open. '
+                        'If "interrupt", this will open the interrupt file.'
+                        'Defaults to YOLACT base model stub from SparseZoo'
+                        )
     parser.add_argument('--top_k', default=5, type=int,
                         help='Further restrict the number of predictions to parse')
     parser.add_argument('--cuda', default=True, type=str2bool,
@@ -313,7 +320,7 @@ def parse_args(argv=None):
     parser.add_argument('--mask_det_file', default='results/mask_detections.json', type=str,
                         help='The output file for coco mask results if --coco_results is set.')
     parser.add_argument('--config', default='yolact_darknet53_config',
-                        help='The config object to use.')
+                        help='The config object to use. Defaults to yolact_darknet53_config (for DarkNet53 backbones). ')
     parser.add_argument('--output_web_json', dest='output_web_json', action='store_true',
                         help='If display is not set, instead of processing IoU values, this dumps detections for usage with the detections viewer web thingy.')
     parser.add_argument('--web_det_path', default='web/dets/', type=str,

--- a/train.py
+++ b/train.py
@@ -210,7 +210,7 @@ parser.add_argument('--fp16',
                     action='store_true',
                     help ='flag to switch off fp16 while training'
                     )
-parser.add_argument('--wandb', action='store_true', help="Flag to use wandb logging")
+parser.add_argument('--wandb', action='store_true', help="Flag to use wandb logging, needs `pip install wandb`")
 parser.add_argument('--cont', action='store_true', help="Flag to continue application of a halted recipe.")
 
 parser.set_defaults(keep_latest=False, log=True, log_gpu=False, interrupt=True, autoscale=True)

--- a/train.py
+++ b/train.py
@@ -2,17 +2,18 @@
 Script to Train YOLACT models
 
 ####################
-usage: train.py [-h] [--batch_size BATCH_SIZE] [--resume RESUME] [--ckpt CKPT]
-                [--start_iter START_ITER] [--num_workers NUM_WORKERS]
-                [--cuda CUDA] [--lr LR] [--momentum MOMENTUM] [--decay DECAY]
-                [--gamma GAMMA] [--save_folder SAVE_FOLDER]
-                [--log_folder LOG_FOLDER] [--config CONFIG]
-                [--save_interval SAVE_INTERVAL]
+usage: train.py [-h] [--batch_size BATCH_SIZE] [--resume RESUME]
+                [--ckpt CKPT] [--start_iter START_ITER]
+                [--num_workers NUM_WORKERS] [--cuda CUDA] [--lr LR]
+                [--momentum MOMENTUM] [--decay DECAY] [--gamma GAMMA]
+                [--save_folder SAVE_FOLDER] [--log_folder LOG_FOLDER]
+                [--config CONFIG] [--save_interval SAVE_INTERVAL]
                 [--validation_size VALIDATION_SIZE]
                 [--validation_epoch VALIDATION_EPOCH] [--keep_latest]
                 [--keep_latest_interval KEEP_LATEST_INTERVAL]
                 [--dataset DATASET] [--no_log] [--log_gpu] [--no_interrupt]
-                [--batch_alloc BATCH_ALLOC] [--no_autoscale] [--recipe RECIPE]
+                [--batch_alloc BATCH_ALLOC] [--no_autoscale]
+                [--recipe RECIPE]
                 [--override_checkpoint_epoch OVERRIDE_CHECKPOINT_EPOCH]
                 [--fp16] [--wandb] [--cont]
 
@@ -22,71 +23,75 @@ optional arguments:
   -h, --help            show this help message and exit
   --batch_size BATCH_SIZE
                         Batch size for training
-  --resume RESUME       Checkpoint state_dict file to resume training from. If
-                        this is "interrupt", the model will resume training
-                        from the interrupt file. Can also be set to True;along
-                        with the --ckpt argument to resume training from a
-                        SparseZoo stub or local checkpoint
-  --ckpt CKPT           Path to a Yolact checkpoint/SparseZoo stub used only
-                        if --resume is True
+  --resume RESUME       Checkpoint state_dict file to resume training from.
+                        If this is "interrupt", the model will resume
+                        training from the interrupt file. Can also be set
+                        to True;along with the --ckpt argument to resume
+                        training from a SparseZoo stub or local checkpoint
+  --ckpt CKPT           Path to a Yolact checkpoint/SparseZoo stub used
+                        only if --resume is True
   --start_iter START_ITER
                         Resume training at this iter. If this is -1, the
-                        iteration will bedetermined from the file name.
+                        iteration will be determined from the file name.
+                        Defaults to 0.
   --num_workers NUM_WORKERS
                         Number of workers used in dataloading
   --cuda CUDA           Use CUDA to train model
   --lr LR, --learning_rate LR
-                        Initial learning rate. Leave as None to read this from
+                        Initial learning rate. Leave as None to read this
+                        from the config.
+  --momentum MOMENTUM   Momentum for SGD. Leave as None to read this from
                         the config.
-  --momentum MOMENTUM   Momentum for SGD. Leave as None to read this from the
-                        config.
   --decay DECAY, --weight_decay DECAY
-                        Weight decay for SGD. Leave as None to read this from
-                        the config.
-  --gamma GAMMA         For each lr step, what to multiply the lr by. Leave as
-                        None to read this from the config.
+                        Weight decay for SGD. Leave as None to read this
+                        from the config.
+  --gamma GAMMA         For each lr step, what to multiply the lr by. Leave
+                        as None to read this from the config.
   --save_folder SAVE_FOLDER
                         Directory for saving checkpoint models.
   --log_folder LOG_FOLDER
                         Directory for saving logs.
-  --config CONFIG       The config object to use.
+  --config CONFIG       The config object to use. Defaults to
+                        yolact_darknet53_config (for DarkNet-53 backbone)
   --save_interval SAVE_INTERVAL
                         The number of iterations between saving the model.
   --validation_size VALIDATION_SIZE
                         The number of images to use for validation.
   --validation_epoch VALIDATION_EPOCH
-                        Output validation information every n iterations. If
-                        -1, do no validation.
-  --keep_latest         Only keep the latest checkpoint instead of each one.
+                        Output validation information every n iterations.
+                        If -1, do no validation.
+  --keep_latest         Only keep the latest checkpoint instead of each
+                        one.
   --keep_latest_interval KEEP_LATEST_INTERVAL
-                        When --keep_latest is on, don't delete the latest file
-                        at these intervals. This should be a multiple of
-                        save_interval or 0.
+                        When --keep_latest is on, don't delete the latest
+                        file at these intervals. This should be a multiple
+                        of save_interval or 0.
   --dataset DATASET     If specified, override the dataset specified in the
                         config with this one (example: coco2017_dataset).
-  --no_log              Don't log per iteration information into log_folder.
-  --log_gpu             Include GPU information in the logs. Nvidia-smi tends
-                        to be slow, so set this with caution.
+  --no_log              Don't log per iteration information into
+                        log_folder.
+  --log_gpu             Include GPU information in the logs. Nvidia-smi
+                        tends to be slow, so set this with caution.
   --no_interrupt        Don't save an interrupt when KeyboardInterrupt is
                         caught.
   --batch_alloc BATCH_ALLOC
-                        If using multiple GPUS, you can set this to be a comma
-                        separated list detailing which GPUs should get what
-                        local batch size (It should add up to your total batch
-                        size).
-  --no_autoscale        YOLACT will automatically scale the lr and the number
-                        of iterations depending on the batch size. Set this if
-                        you want to disable that.
+                        If using multiple GPUS, you can set this to be a
+                        comma separated list detailing which GPUs should
+                        get what local batch size (It should add up to your
+                        total batch size).
+  --no_autoscale        YOLACT will automatically scale the lr and the
+                        number of iterations depending on the batch size.
+                        Set this if you want to disable that.
   --recipe RECIPE       Path to a sparsification recipe, can also be a
-                        SparseZoo recipe stub, if provided the recipe stored
-                        with the checkpoint is ignored
+                        SparseZoo recipe stub, if provided the recipe
+                        stored with the checkpoint is ignored
   --override_checkpoint_epoch OVERRIDE_CHECKPOINT_EPOCH
                         True to to override epoch # saved in the checkpoint
                         and start from 0
   --fp16                flag to switch off fp16 while training
-  --wandb               Flag to use wandb logging
+  --wandb               Flag to use wandb logging, needs `pip install
+                        wandb`
   --cont                Flag to continue application of a halted recipe.
-
 ####################
 Example Usage:
 # Start from a pretrained checkpoint and apply a recipe, both resume
@@ -100,6 +105,11 @@ python train.py --resume weights/model.pth \
 python train.py --resume \
 zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
 --recipe yolact.pruned.perf.md
+
+3) # Using SparseZoo Stubs for model and recipe
+python train.py --resume \
+zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
+--recipe zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none
 
 ####################
 Some Useful Model Stubs:
@@ -154,8 +164,8 @@ parser.add_argument('--resume', default=None, type=str,
 parser.add_argument('--ckpt', type=str, default=None,
                     help="Path to a Yolact checkpoint/SparseZoo stub used only if --resume is True")
 parser.add_argument('--start_iter', default=0, type=int,
-                    help='Resume training at this iter. If this is -1, the iteration will be'\
-                         'determined from the file name.')
+                    help='Resume training at this iter. If this is -1, the iteration will be'
+                         ' determined from the file name. Defaults to 0.')
 parser.add_argument('--num_workers', default=4, type=int,
                     help='Number of workers used in dataloading')
 parser.add_argument('--cuda', default=True, type=str2bool,
@@ -173,7 +183,7 @@ parser.add_argument('--save_folder', default='weights/',
 parser.add_argument('--log_folder', default='logs/',
                     help='Directory for saving logs.')
 parser.add_argument('--config', default='yolact_darknet53_config',
-                    help='The config object to use.')
+                    help='The config object to use. Defaults to yolact_darknet53_config (for DarkNet-53 backbone)')
 parser.add_argument('--save_interval', default=10000, type=int,
                     help='The number of iterations between saving the model.')
 parser.add_argument('--validation_size', default=5000, type=int,

--- a/train.py
+++ b/train.py
@@ -1,3 +1,116 @@
+"""
+Script to Train YOLACT models
+
+####################
+usage: train.py [-h] [--batch_size BATCH_SIZE] [--resume RESUME] [--ckpt CKPT]
+                [--start_iter START_ITER] [--num_workers NUM_WORKERS]
+                [--cuda CUDA] [--lr LR] [--momentum MOMENTUM] [--decay DECAY]
+                [--gamma GAMMA] [--save_folder SAVE_FOLDER]
+                [--log_folder LOG_FOLDER] [--config CONFIG]
+                [--save_interval SAVE_INTERVAL]
+                [--validation_size VALIDATION_SIZE]
+                [--validation_epoch VALIDATION_EPOCH] [--keep_latest]
+                [--keep_latest_interval KEEP_LATEST_INTERVAL]
+                [--dataset DATASET] [--no_log] [--log_gpu] [--no_interrupt]
+                [--batch_alloc BATCH_ALLOC] [--no_autoscale] [--recipe RECIPE]
+                [--override_checkpoint_epoch OVERRIDE_CHECKPOINT_EPOCH]
+                [--fp16] [--wandb] [--cont]
+
+Yolact Training Script
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --batch_size BATCH_SIZE
+                        Batch size for training
+  --resume RESUME       Checkpoint state_dict file to resume training from. If
+                        this is "interrupt", the model will resume training
+                        from the interrupt file. Can also be set to True;along
+                        with the --ckpt argument to resume training from a
+                        SparseZoo stub or local checkpoint
+  --ckpt CKPT           Path to a Yolact checkpoint/SparseZoo stub used only
+                        if --resume is True
+  --start_iter START_ITER
+                        Resume training at this iter. If this is -1, the
+                        iteration will bedetermined from the file name.
+  --num_workers NUM_WORKERS
+                        Number of workers used in dataloading
+  --cuda CUDA           Use CUDA to train model
+  --lr LR, --learning_rate LR
+                        Initial learning rate. Leave as None to read this from
+                        the config.
+  --momentum MOMENTUM   Momentum for SGD. Leave as None to read this from the
+                        config.
+  --decay DECAY, --weight_decay DECAY
+                        Weight decay for SGD. Leave as None to read this from
+                        the config.
+  --gamma GAMMA         For each lr step, what to multiply the lr by. Leave as
+                        None to read this from the config.
+  --save_folder SAVE_FOLDER
+                        Directory for saving checkpoint models.
+  --log_folder LOG_FOLDER
+                        Directory for saving logs.
+  --config CONFIG       The config object to use.
+  --save_interval SAVE_INTERVAL
+                        The number of iterations between saving the model.
+  --validation_size VALIDATION_SIZE
+                        The number of images to use for validation.
+  --validation_epoch VALIDATION_EPOCH
+                        Output validation information every n iterations. If
+                        -1, do no validation.
+  --keep_latest         Only keep the latest checkpoint instead of each one.
+  --keep_latest_interval KEEP_LATEST_INTERVAL
+                        When --keep_latest is on, don't delete the latest file
+                        at these intervals. This should be a multiple of
+                        save_interval or 0.
+  --dataset DATASET     If specified, override the dataset specified in the
+                        config with this one (example: coco2017_dataset).
+  --no_log              Don't log per iteration information into log_folder.
+  --log_gpu             Include GPU information in the logs. Nvidia-smi tends
+                        to be slow, so set this with caution.
+  --no_interrupt        Don't save an interrupt when KeyboardInterrupt is
+                        caught.
+  --batch_alloc BATCH_ALLOC
+                        If using multiple GPUS, you can set this to be a comma
+                        separated list detailing which GPUs should get what
+                        local batch size (It should add up to your total batch
+                        size).
+  --no_autoscale        YOLACT will automatically scale the lr and the number
+                        of iterations depending on the batch size. Set this if
+                        you want to disable that.
+  --recipe RECIPE       Path to a sparsification recipe, can also be a
+                        SparseZoo recipe stub, if provided the recipe stored
+                        with the checkpoint is ignored
+  --override_checkpoint_epoch OVERRIDE_CHECKPOINT_EPOCH
+                        True to to override epoch # saved in the checkpoint
+                        and start from 0
+  --fp16                flag to switch off fp16 while training
+  --wandb               Flag to use wandb logging
+  --cont                Flag to continue application of a halted recipe.
+
+####################
+Example Usage:
+# Start from a pretrained checkpoint and apply a recipe, both resume
+and recipe arguments can be replaced by valid SparseZoo stubs
+
+1) # Using local weights
+python train.py --resume weights/model.pth \
+ --recipe recipe.yaml
+
+2) # Using SparseZoo Stubs
+python train.py --resume \
+zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
+--recipe yolact.pruned.perf.md
+
+####################
+Some Useful Model Stubs:
+1) Base YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none
+2) Pruned YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none
+3) Pruned Quantized YOLACT
+    zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned82_quant-none
+
+"""
 import logging
 
 from sparseml.pytorch.utils import TensorBoardLogger
@@ -10,7 +123,7 @@ from utils.logger import Log
 from utils import timer
 from layers.modules import MultiBoxLoss
 from utils.sparse import SparseMLWrapper
-from utils.zoo import is_valid_stub, download_checkpoint_from_stub
+from utils.zoo import is_valid_stub, get_checkpoint_from_stub
 from yolact import Yolact
 import os
 import time
@@ -40,7 +153,7 @@ parser.add_argument('--resume', default=None, type=str,
                     )
 parser.add_argument('--ckpt', type=str, default=None,
                     help="Path to a Yolact checkpoint/SparseZoo stub used only if --resume is True")
-parser.add_argument('--start_iter', default=-1, type=int,
+parser.add_argument('--start_iter', default=0, type=int,
                     help='Resume training at this iter. If this is -1, the iteration will be'\
                          'determined from the file name.')
 parser.add_argument('--num_workers', default=4, type=int,
@@ -59,7 +172,7 @@ parser.add_argument('--save_folder', default='weights/',
                     help='Directory for saving checkpoint models.')
 parser.add_argument('--log_folder', default='logs/',
                     help='Directory for saving logs.')
-parser.add_argument('--config', default=None,
+parser.add_argument('--config', default='yolact_darknet53_config',
                     help='The config object to use.')
 parser.add_argument('--save_interval', default=10000, type=int,
                     help='The number of iterations between saving the model.')
@@ -227,9 +340,11 @@ def train():
         args.resume = SavePath.get_latest(args.save_folder, cfg.name)
     elif str2bool(args.resume):
         if is_valid_stub(args.ckpt):
-            args.resume = download_checkpoint_from_stub(args.ckpt)
+            args.resume = get_checkpoint_from_stub(args.ckpt)
         else:
             args.resume = args.ckpt
+    elif is_valid_stub(args.resume):
+        args.resume = get_checkpoint_from_stub(args.resume)
 
     if args.resume and args.resume.lower() not in ("no", "false", "f", "0"):
         print('Resuming training, loading checkpoint {}...'.format(args.resume))
@@ -400,13 +515,8 @@ def train():
                     time_avg.add(elapsed)
 
                 if iteration % 10 == 0:
-                    remaining_epoch_iterations = len(data_loader) - (iteration % len(data_loader))
-                    remaining_complete_epochs = (num_epochs - epoch - 1)
-                    remaining_iterations = remaining_epoch_iterations + remaining_complete_epochs * len(data_loader)
-                    eta_current_setup = datetime.timedelta(seconds=((remaining_iterations * time_avg.get_avg())))
-                    eta_max = datetime.timedelta(seconds=((max_steps - iteration) * time_avg.get_avg()))
-
-                    eta_str = str(min(eta_current_setup, eta_max)).split('.')[0]
+                    eta_str = get_eta(data_loader, epoch, iteration, max_steps,
+                                      num_epochs, time_avg)
                     total = sum([loss_avgs[k].get_avg() for k in losses])
                     loss_labels = sum([[k, loss_avgs[k].get_avg()] for k in loss_types if k in losses], [])
 
@@ -473,6 +583,19 @@ def train():
     compute_validation_map(epoch, iteration, yolact_net, val_dataset,
                            log if args.log else None)
 
+
+def get_eta(data_loader, epoch, iteration, max_steps, num_epochs, time_avg):
+    remaining_epoch_iterations = len(data_loader) - (
+                iteration % len(data_loader))
+    remaining_complete_epochs = (num_epochs - epoch - 1)
+    remaining_iterations = remaining_epoch_iterations + remaining_complete_epochs * len(
+        data_loader)
+    eta_current_setup = datetime.timedelta(
+        seconds=((remaining_iterations * time_avg.get_avg())))
+    eta_max = datetime.timedelta(
+        seconds=((max_steps - iteration) * time_avg.get_avg()))
+    eta_str = str(min(eta_current_setup, eta_max)).split('.')[0]
+    return eta_str
 
 
 def set_lr(optimizer, new_lr):

--- a/utils/engines.py
+++ b/utils/engines.py
@@ -1,0 +1,45 @@
+"""
+Utility classes and methods for supported engines
+"""
+from enum import Enum
+
+class _ExtendedEnum(Enum):
+    @classmethod
+    def supported(cls):
+        return list(map(lambda c: c.value, cls))
+
+
+class Engine(_ExtendedEnum):
+    """
+    Class representing supported Inference Engines
+    """
+    DEEPSPARSE = 'deepsparse'
+    ORT = 'ort'
+    TORCH = 'torch'
+
+    @classmethod
+    def from_filepath(cls, filepath: str, default_onnx=None):
+        """
+        Try to infer engine from filename;
+        Note this is experimental and might fail; if no filepath given defaults
+        to TORCH, Default engine for ONNX is DeepSparse, for ORT engine pass a
+        default parameter with 'ort'
+
+        :param filepath:
+        :return:
+        """
+        if (
+                not filepath or filepath.endswith('.pt')
+                or filepath.endswith('.pth')
+        ):
+            return Engine.TORCH
+
+        if not default_onnx or default_onnx != 'ort':
+            default_onnx = Engine.DEEPSPARSE
+        else:
+            default_onnx = Engine.ORT
+
+        if filepath.endswith('.onnx') or filepath.startswith('zoo:'):
+            return default_onnx
+
+        raise ValueError(f"Cannot Infer Engine from {filepath}")

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -59,7 +59,7 @@ class SparseMLWrapper(object):
             SparsificationGroupLogger(
                 lambda_func=_logging_lambda,
                 tensorboard=tb_writer,
-                wandb_={'project': 'yolact'}
+                wandb_={'project': 'yolact'} if wandb_logger else None,
             )
         ])
 

--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -1,32 +1,92 @@
+from abc import ABC, abstractmethod
 import contextlib
-
-import torch
-
-with contextlib.suppress(ModuleNotFoundError):
-    from deepsparse import compile_model
-    from deepsparse.utils import generate_random_inputs
 
 from layers import Detect
 from yolact import FastMaskIoUNet
 
+with contextlib.suppress(ModuleNotFoundError):
+    from deepsparse import compile_model
 
-class DeepsparseWrapper:
+with contextlib.suppress(ModuleNotFoundError):
+    import onnxruntime as ort
+
+import torch
+
+
+def _convert_tensors_to_numpy(inputs):
+    if torch.is_tensor(inputs):
+        inputs = inputs.cpu().numpy()
+    return inputs
+
+
+def _make_list(inputs):
+    if not isinstance(inputs, list):
+        batch = [inputs]
+    return batch
+
+
+class YOLACTWrapper(ABC):
+    """
+    Base abstract class for wrapping YOLACT inference
+    """
+    def __init__(self, cfg):
+        self.detect = Detect(cfg.num_classes, bkg_label=0, top_k=cfg.nms_top_k,
+                              conf_thresh=cfg.nms_conf_thresh,
+                              nms_thresh=cfg.nms_thresh)
+        self._maskiou_net = FastMaskIoUNet()
+        self._keys = ['loc', 'conf', 'mask', 'priors', 'proto']
+
+    def __call__(self, _inputs):
+        """
+        Run inputs through the graph and return returns detections
+
+        :param _inputs: tensor type inputs
+        """
+        _inputs = _convert_tensors_to_numpy(_inputs)
+        _outputs = self.forward(_inputs)
+        return self._postprocess(_outputs)
+
+    def _postprocess(self, outputs):
+        if isinstance(outputs, dict):
+            _outputs_iter = outputs.values()
+        else:
+            _outputs_iter = outputs
+        outs = dict(zip(self._keys, map(torch.from_numpy, _outputs_iter)))
+        return self.detect(outs, self)
+
+    @abstractmethod
+    def forward(self, *args, **kwargs):
+        """
+        Forward inputs through the model graph returns outputs
+
+        :pre-condition: Expects numpy type inputs
+        :post-condition: Returns numpy type outputs
+        """
+        pass
+
+
+class DeepSparseWrapper(YOLACTWrapper):
+    """
+    Inference Wrapper for YOLACT that uses DeepSparse Engine
+    """
     def __init__(self, filepath, cfg, num_cores=None,
                  batch_size=1):
+        super().__init__(cfg)
         self.engine = compile_model(filepath, batch_size=batch_size,
                                     num_cores=num_cores)
-        self.detect = Detect(cfg.num_classes, bkg_label=0, top_k=cfg.nms_top_k,
-                             conf_thresh=cfg.nms_conf_thresh,
-                             nms_thresh=cfg.nms_thresh)
-        self.maskiou_net = FastMaskIoUNet()
 
-    def __call__(self, inputs):
-        if torch.is_tensor(inputs):
-            inputs = inputs.cpu().numpy()
-        batch = inputs
-        if not isinstance(inputs, list):
-            batch = [inputs]
-        outs = self.engine.mapped_run(batch)
-        keys = ['loc', 'conf', 'mask', 'priors', 'proto']
-        outs = dict(zip(keys, map(torch.from_numpy, outs.values())))
-        return self.detect(outs, self)
+    def forward(self, inputs):
+        batch = _make_list(inputs)
+        return self.engine.mapped_run(batch)
+
+
+class ORTWrapper(YOLACTWrapper):
+    """
+    Inference Wrapper for YOLACT that uses ONNX Runtime Engine
+    """
+    def __init__(self, filepath, cfg):
+        super().__init__(cfg)
+        self.engine = ort.InferenceSession(filepath)
+
+    def forward(self, inputs):
+        return self.engine.run(None, {'input': inputs})

--- a/utils/zoo.py
+++ b/utils/zoo.py
@@ -1,18 +1,34 @@
+from pathlib import Path
 from sparsezoo import Zoo
+from functools import wraps
 
 
 def is_valid_stub(stub: str) -> bool:
-    return stub.startswith('zoo:')
+    return stub and stub.startswith('zoo:')
+
+
+def is_onnx(onnx_file: str) -> bool:
+    return onnx_file and Path(onnx_file).suffix == '.onnx'
+
+
+def check_stub_before_invoke(func):
+    @wraps(func)
+    def wrapper(stub: str, *args, **kwargs):
+        if is_valid_stub(stub):
+            return func(stub, *args, **kwargs)
+        raise ValueError("Invalid Stub, Check for typo!!!")
+
+    return wrapper
 
 
 def _get_model_framework_file(model, path: str):
     transfer_request = 'recipe_type=transfer' in path
     checkpoint_available = any(
         file.checkpoint for file in model.framework_files
-        )
+    )
     final_available = any(
         not file.checkpoint for file in model.framework_files
-        )
+    )
 
     if transfer_request and checkpoint_available:
         # checkpoints are saved for transfer learning use cases,
@@ -27,7 +43,20 @@ def _get_model_framework_file(model, path: str):
     raise ValueError(f"Could not find a valid framework file for {path}")
 
 
-def download_checkpoint_from_stub(stub: str) -> str:
+@check_stub_before_invoke
+def get_model_onnx_from_stub(stub: str):
+    """
+    Downloads model from stub and returns its onnx filepath
+
+    :param stub: SparseZoo stub for the model
+    :return: path to model.onnx for the specified stub
+    """
+    model = Zoo.load_model_from_stub(stub=stub)
+    return model.onnx_file.downloaded_path()
+
+
+@check_stub_before_invoke
+def get_checkpoint_from_stub(stub: str) -> str:
     """
     Helper to download a model checkpoint from SparseZoo Stub
 
@@ -38,11 +67,7 @@ def download_checkpoint_from_stub(stub: str) -> str:
     :return: path to model checkpoint (after downloading from SparseZoo)
     """
 
-    if is_valid_stub(stub=stub):
-        model = Zoo.load_model_from_stub(stub=stub)
-        file = _get_model_framework_file(model, stub)
-        path = file.downloaded_path()
-        return path
-
-    raise ValueError("Invalid Stub, Check for typo!!!")
-
+    model = Zoo.load_model_from_stub(stub=stub)
+    file = _get_model_framework_file(model, stub)
+    path = file.downloaded_path()
+    return path


### PR DESCRIPTION
- Removed Minor bugs
- Added support for ORT engine in evaluation
- Added example commands
- default config kept as `yolact_darknet53_config`
- default `start_iter` made zero as opposed = `-1`,
  (prevents reading start iteration from checkpoint name)