### PR TITLE
Add support for recipe stages

### DIFF
--- a/train.py
+++ b/train.py
@@ -445,6 +445,10 @@ def train():
 
     # try-except so you can use ctrl+c to save early and stop training
     # SparseML Integration
+    last_stage_epoch = 0
+
+    if sparseml_wrapper.checkpoint_recipe_manager:
+        last_stage_epoch = sparseml_wrapper.checkpoint_recipe_manager.max_epochs or 0
 
     try:
         for epoch in range(start_epoch, num_epochs):
@@ -563,7 +567,7 @@ def train():
                     yolact_net.save_checkpoint(
                         save_path(epoch, iteration),
                         recipe=sparseml_wrapper.state_dict().get('recipe'),
-                        epoch=epoch,
+                        epoch=epoch + last_stage_epoch,
                     )
 
                     if args.keep_latest and latest is not None:
@@ -587,14 +591,14 @@ def train():
             yolact_net.save_checkpoint(
                 save_path(epoch, repr(iteration) +'_interrupt'),
                 recipe=sparseml_wrapper.state_dict().get('recipe'),
-                epoch=epoch,
+                epoch=epoch + last_stage_epoch,
             )
         exit()
 
     yolact_net.save_checkpoint(
         save_path(epoch, iteration),
         recipe=sparseml_wrapper.state_dict().get('recipe'),
-        epoch=epoch,
+        epoch=epoch + last_stage_epoch,
     )
     # Compute validation mAP after training is finished
     print("Computing val mAP after training:")

--- a/train.py
+++ b/train.py
@@ -367,21 +367,23 @@ def train():
 
     if args.resume and args.resume.lower() not in ("no", "false", "f", "0"):
         print('Resuming training, loading checkpoint {}...'.format(args.resume))
-        checkpoint_epoch, checkpoint_recipe, sparseml_wrapper = yolact_net.load_checkpoint(args.resume, args.recipe, resume=args.cont)
-        start_epoch = 0
-        if checkpoint_epoch and args.cont:
-            start_epoch = checkpoint_epoch
-        if not args.use_checkpoint_epoch:
-            start_epoch = 0
-        args.recipe = args.recipe or checkpoint_recipe
+        start_epoch, train_recipe, sparseml_wrapper = yolact_net.load_checkpoint(
+            path=args.resume,
+            train_recipe=args.recipe,
+            resume=args.cont,
+        )
+        args.recipe = train_recipe
         if args.start_iter == -1:
             args.start_iter = SavePath.from_str(args.resume).iteration
     else:
         print('Initializing weights...')
         yolact_net.init_weights(backbone_path=args.save_folder + cfg.backbone.path)
-        start_epoch= 0
-        sparseml_wrapper = SparseMLWrapper(yolact_net, args.recipe)
-        sparseml_wrapper.initialize(start_epoch=start_epoch)
+        sparseml_wrapper = SparseMLWrapper(
+            model=yolact_net,
+            recipe=args.recipe,
+        )
+        # A new run always starts from epoch 0
+        sparseml_wrapper.initialize(start_epoch=0)
 
     optimizer = optim.SGD(net.parameters(), lr=args.lr, momentum=args.momentum,
                           weight_decay=args.decay)
@@ -454,7 +456,7 @@ def train():
                 half_precision = False
 
             # Resume from start_iter
-            if (epoch+1)*epoch_size < iteration:
+            if (epoch+1) * epoch_size < iteration:
                 continue
             
             for datum in data_loader:
@@ -561,7 +563,8 @@ def train():
                     yolact_net.save_checkpoint(
                         save_path(epoch, iteration),
                         recipe=sparseml_wrapper.state_dict().get('recipe'),
-                        epoch=epoch)
+                        epoch=epoch,
+                    )
 
                     if args.keep_latest and latest is not None:
                         if args.keep_latest_interval <= 0 or iteration % args.keep_latest_interval != args.save_interval:

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -56,7 +56,7 @@ class SparseMLWrapper(object):
 
     def state_dict(self):
         """
-        :return: A dict object with compsed recipe
+        :return: A dict object with composed recipe
         """
         return {
             'recipe': str(self.compose_recipes()) if self.enabled else None,
@@ -137,7 +137,7 @@ class SparseMLWrapper(object):
     def should_override_scheduler(self):
         return self.enabled and self.manager.learning_rate_modifiers
 
-    def check_epoch_override(self, epochs):
+    def check_epoch_override(self, epochs) -> Union[int, float]:
         """
         Override num epochs if recipe explicitly modifies epoch range
 
@@ -153,7 +153,7 @@ class SparseMLWrapper(object):
 
         return epochs
 
-    def qat_active(self, epoch):
+    def qat_active(self, epoch) -> bool:
         """
         :param epoch: Epoch number to test for
         :return: True if qat active at specified epoch else False

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -177,6 +177,6 @@ class SparseMLWrapper(object):
             return self.manager
 
         return self.manager.compose_staged(
-            base_recipe=self.recipe, additional_recipe=self.checkpoint_recipe_manager,
+            base_recipe=self.checkpoint_recipe_manager, additional_recipe=self.recipe,
         )
 

--- a/yolact.py
+++ b/yolact.py
@@ -1,6 +1,7 @@
 import torch, torchvision
 import torch.nn as nn
 import torch.nn.functional as F
+from sparseml.pytorch.optim import ScheduledModifierManager
 from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
@@ -478,22 +479,28 @@ class Yolact(nn.Module):
         checkpoint = {
                          'epoch': epoch,
                          'model_state_dict': self.state_dict(),
-                         'recipe': recipe,
+                         'checkpoint_recipe': recipe,
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(self, path, train_recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
-        :return: A tuple containing the epoch and the recipe if
+        :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """
 
-        checkpoint = torch.load(path)
-        epoch = checkpoint.get('epoch')
-        recipe = recipe or checkpoint.get('recipe')
-        state_dict = checkpoint.get('model_state_dict', checkpoint)
-        sparseml_wrapper = SparseMLWrapper(self, recipe)
+        loaded_checkpoint = torch.load(path)
+        checkpoint_epoch = loaded_checkpoint.get('epoch', float('inf'))
+        checkpoint_recipe = loaded_checkpoint.get('checkpoint_recipe')
+        state_dict = loaded_checkpoint.get('model_state_dict', loaded_checkpoint)
+
+        sparseml_wrapper = SparseMLWrapper(
+            model=self,
+            recipe=train_recipe,
+            checkpoint_recipe=checkpoint_recipe,
+            checkpoint_epoch=float('inf') if not resume else checkpoint_epoch,
+        )
 
         # For backward compatability, remove these (the new variable is called layers)
         for key in list(state_dict.keys()):
@@ -514,10 +521,20 @@ class Yolact(nn.Module):
                 self.load_state_dict(state_dict)
 
                 loaded = True
-            sparseml_wrapper.initialize(start_epoch=epoch or 0 if resume else 0)
+            start_epoch = 0
+
+            if resume and checkpoint_epoch != float('inf'):
+                start_epoch = checkpoint_epoch
+
+            sparseml_wrapper.initialize(start_epoch=start_epoch)
         if not loaded:
             self.load_state_dict(state_dict=state_dict)
-        return epoch or 0, recipe, sparseml_wrapper
+
+        start_epoch = 0
+        if resume and checkpoint_epoch != float('inf'):
+            start_epoch = checkpoint_epoch
+
+        return start_epoch, train_recipe, sparseml_wrapper
 
     def init_weights(self, backbone_path):
         """ Initialize weights for training. """

--- a/yolact.py
+++ b/yolact.py
@@ -483,9 +483,17 @@ class Yolact(nn.Module):
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, train_recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(
+        self,
+        path: str,
+        train_recipe: Optional[str] = None,
+        resume: bool = False,
+    ) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
+        :param path: local path to the checkpoint
+        :param train_recipe: A train recipe if different from checkpoint recipe
+        :param resume: True if resuming a last run
         :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """


### PR DESCRIPTION
This PR Adds support for recipe stages with YOLACT

If applied in the current state this PR will
* Create a checkpoint_recipe_manager in `SparseMLWrapper`
* Add a compose recipes function to create a staged recipe with structural changes from both checkpoint_recipe + train_recipe
* Rename variables to make more intuitive sense
* Hide creation of checkpoint_recipe_manager behind `SparseMLWrapper`

The test run is as follows:
original model: `zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none`
checkpoint_recipe:

`small-quant.yaml`
```yaml
num_epochs: 2
quantization_start_target: 0
quantization_end_target: 1
quantization_observer_end_target: 0.5
training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0.0
    end_epoch: eval(num_epochs)

  - !SetWeightDecayModifier
    start_epoch: eval(quantization_start_target * num_epochs)
    weight_decay: 0.0

  - !LearningRateFunctionModifier
    start_epoch: 0
    end_epoch: eval(quantization_end_target * num_epochs)
    lr_func: linear
    init_lr: 0.00001
    final_lr: 0.000001

pruning_modifiers:
  - !ConstantPruningModifier
    start_epoch: 0.0
    params: __ALL_PRUNABLE__

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(quantization_start_target * num_epochs)
    disable_quantization_observer_epoch: eval(quantization_observer_end_target * num_epochs)
    freeze_bn_stats_epoch: eval(quantization_observer_end_target * num_epochs)
```

train_recipe:
`new-recipe.yaml`
```yaml
training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: 10
```


Composed run command:
```bash
sparseml.yolact.train \
--recipe ~/projects/yolact/recipes/new-recipe.yaml \
--resume ./quant-checkpoint-with-recipe/yolact_darknet53_0_48_interrupt.pth \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images \
--save_folder ./quant-checkpoint-with-stages
```

Composed Recipe
```python
In [1]: import torch

In [2]: import pprint

In [3]: checkpoint_recipe = torch.load("./quant-checkpoint-with-stages/yolact_darknet53_0_19_interrupt.pth")["checkpoint_recipe"]

In [5]: pprint.pprint(checkpoint_recipe)
('version: 1.1.0\n'
 '\n'
 'stage_0:\n'
 '  __metadata__: None\n'
 '\n'
 '  stage_0_modifiers:\n'
 '      - !ConstantPruningModifier\n'
 '          end_epoch: 2\n'
 '          params: __ALL_PRUNABLE__\n'
 '          start_epoch: 0.0\n'
 '          update_frequency: -1\n'
 '  \n'
 '      - !EpochRangeModifier\n'
 '          end_epoch: 2\n'
 '          start_epoch: 0.0\n'
 '  \n'
 '      - !LearningRateFunctionModifier\n'
 '          cycle_epochs: 1.0\n'
 '          end_epoch: 2\n'
 '          final_lr: 1e-06\n'
 '          init_lr: 1e-05\n'
 '          lr_func: linear\n'
 '          start_epoch: 0\n'
 '          update_frequency: -1.0\n'
 '  \n'
 '      - !QuantizationModifier\n'
 '          activation_bits: 8\n'
 '          disable_quantization_observer_epoch: 1.0\n'
 '          end_epoch: 2\n'
 '          exclude_batchnorm: True\n'
 "          exclude_module_types: ['BatchNorm1d', 'BatchNorm2d', "
 "'BatchNorm3d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d']\n"
 '          freeze_bn_stats_epoch: 1.0\n'
 '          model_fuse_fn_name: conv_bn_relus\n'
 '          quantize_conv_activations: True\n'
 '          quantize_embedding_activations: True\n'
 '          quantize_embeddings: True\n'
 '          quantize_linear_activations: True\n'
 '          reduce_range: False\n'
 '          start_epoch: 0\n'
 '          tensorrt: False\n'
 '          weight_bits: 8\n'
 '  \n'
 '      - !SetWeightDecayModifier\n'
 '          constant_logging: False\n'
 '          end_epoch: 2\n'
 '          start_epoch: 0\n'
 '          weight_decay: 0.0\n'
 '  \n'
 '\n'
 'stage_1:\n'
 '  __metadata__: None\n'
 '\n'
 '  stage_1_modifiers:\n'
 '      - !EpochRangeModifier\n'
 '          end_epoch: 12\n'
 '          start_epoch: 2\n'
 '  \n')

```

