### PR TITLE
Added support for yolact auto-build

### DIFF
--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -1,0 +1,30 @@
+---
+name: Upload Nightly Wheel
+
+on:
+  push:
+    branches:
+      - "master"
+      - "auto-build"
+
+jobs:
+  build-wheel:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build wheel
+        run: |
+          ./build_wheel.sh
+          echo "::set-output name=wheel_path::$(find "dist/" -type f -name "*.whl")"
+          echo "::set-output name=wheel_name::$(basename $(find "dist/" -type f -name "*.whl"))"
+        id: build_wheel
+      - name: Upload Wheel Asset
+        id: upload-release-asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_wheel.outputs.wheel_path }}
+          asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
+          tag: "nightly"
+          overwrite: true

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - "master"
-      - "auto-build"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-release.yml
+++ b/.github/workflows/build-wheel-release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build wheel
-        run: | 
+        run: |
           ./build_wheel.sh
           echo "::set-output name=wheel_path::$(ls dist/*.whl)"
           echo "::set-output name=wheel_name::$(basename $(ls dist/*.whl))"

--- a/.github/workflows/build-wheel-release.yml
+++ b/.github/workflows/build-wheel-release.yml
@@ -1,0 +1,38 @@
+---
+name: Upload Release Wheel
+
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  build-wheel:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build wheel
+        run: | 
+          ./build_wheel.sh
+          echo "::set-output name=wheel_path::$(ls dist/*.whl)"
+          echo "::set-output name=wheel_name::$(basename $(ls dist/*.whl))"
+        id: build_wheel
+      - name: Get Tag
+        id: extract_tag
+        run: echo "##[set-output name=tag;]$(echo v${GITHUB_REF_NAME#*/})"
+      - name: Tag Repo
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: ${{ steps.extract_tag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Wheel Asset
+        id: upload-release-asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_wheel.outputs.wheel_path }}
+          asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
+          tag: ${{ steps.extract_tag.outputs.tag }}
+          overwrite: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include *.md
+include LICENSE
+include setup.py
+recursive-include yolact/scripts *
+recursive-include yolact/external *
+recursive-include yolact/web *
+include yolact/requirements.txt

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+#************************************************#
+#           build_wheel.sh                       #
+#    Build a Python3 wheel for YOLACT            #
+#************************************************#
+
+REPO_NAME="yolact"
+NEEDED_FOLDERS=("data" "external" "layers" "scripts" "utils" "web")
+REQUIREMENTS_FILE="requirements.txt"
+PYTHON_EXTENSION=".py"
+PACKAGE_TEST_DIR="/tmp/$USER/pip_package_test"
+
+# --------------------------------------------------------- #
+# main ()                                                   #
+# drives the entire build process                           #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+main() {
+  echo "Starting build ..."
+  pre_build_setup &&
+    build &&
+    post_build_test_and_teardown &&
+    echo "Build Successful ... "
+}
+
+# --------------------------------------------------------- #
+# pre_build_setup ()                                        #
+# performs necessary setup for building a YOLACT wheel      #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+pre_build_setup() {
+  echo "Pre-Build Setup ... "
+  __validate_files && __copy_files && __fix_requirements && __build_setup
+}
+
+# --------------------------------------------------------- #
+# build ()                                                  #
+# actual build happens here                                 #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+build() {
+  echo "Build ... "
+  python3 -m build
+  rm --recursive "${REPO_NAME}"
+}
+
+# --------------------------------------------------------- #
+# post_build_test_and_teardown ()                           #
+# installation check + cleanup unnecessary files            #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+post_build_test_and_teardown() {
+  echo "Post-Build Test and Teardowns ... "
+  __test_build
+  __teardown
+}
+
+__validate_files() {
+  echo "Validating files ... "
+  # venv
+  if [[ ! -e "$(command -v python3)" ]]; then
+    echo "Is python installed?" 1>&2
+    return 1
+  fi
+
+  # setup.py
+  if [[ ! -e "setup.py" ]]; then
+    echo "setup.py file not found" 1>&2
+    return 3
+  fi
+}
+
+__copy_files() {
+  echo "Copying files ... "
+
+  # create empty yolact dir, overwrite if exists
+  [[ -d ${REPO_NAME} ]] && rm --recursive ${REPO_NAME}
+  mkdir --parents "${REPO_NAME}"
+
+  for folder in "${NEEDED_FOLDERS[@]}"; do
+    cp --recursive "${folder}" "${REPO_NAME}"
+    grep --include=\*.py -rnl "${REPO_NAME}/" -e "from ${folder}" | xargs -i@ sed -i "s/from ${folder}/from ${REPO_NAME}.${folder}/g" @
+  done
+
+  echo "Copying ${REQUIREMENTS_FILE} ... "
+  cp "${REQUIREMENTS_FILE}" "${REPO_NAME}"
+
+  echo "Finding and Copying Python Files ... "
+  find . -maxdepth 1 -type f -name "*${PYTHON_EXTENSION}" -exec cp {} "${REPO_NAME}" \;
+
+}
+
+__fix_requirements() {
+  sed -i '/^sparseml/d' "${REPO_NAME}/${REQUIREMENTS_FILE}"
+}
+
+__build_setup() {
+  # install build-tools
+  python3 -m pip install --upgrade build
+
+  package_name="$(python3 setup.py --name)"
+  package_version="$(python3 setup.py --version)"
+
+  if [[ -z "$package_name" || -z "$package_version" ]]; then
+    echo "Could not determine package name/version (found ${package_name}==${package_version})" 1>&2
+    return 4
+  fi
+  echo "Package: ${package_name}==${package_version}"
+
+  # Cleanup old dist folder
+  if [[ -e dist ]]; then
+    echo "Removing old releases in dist/* ... "
+    rm --recursive --force dist/ || return 5
+  fi
+
+  echo "NM_INTEGRATED=True" >>"${REPO_NAME}/__init__.py"
+}
+
+__test_build() {
+  # shellcheck disable=SC2174
+  mkdir -m 700 -p "${PACKAGE_TEST_DIR}" || return 11
+  whl_file=$(find "dist/" -type f -name "*.whl")
+
+  echo "Attempting to install ${whl_file}"
+  python3 -m pip install --target "${PACKAGE_TEST_DIR}" --upgrade "${whl_file}"
+  package_was_installed="$?"
+
+  if [[ "${package_was_installed}" -ne "0" ]]; then
+    echo "FAILED TO INSTALL ${whl_file} (status=${package_was_installed})" 1>&2
+    return 13
+  fi
+}
+
+__teardown() {
+  rm --recursive --force "${PACKAGE_TEST_DIR}" || return 12
+}
+
+main;

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import setuptools
 import os
+import setuptools
+from setuptools import find_packages
 
 
 def read_requirements():
@@ -9,15 +10,10 @@ def read_requirements():
 
 
 def packages():
-    return [
-        'yolact',
-        'yolact.data',
-        'yolact.external',
-        'yolact.layers',
-        'yolact.scripts',
-        'yolact.utils',
-        'yolact.web',
-    ]
+    return find_packages(
+        exclude=["*.__pycache__.*"]
+    )
+
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+import setuptools
+import os
+
+
+def read_requirements():
+    build_dir = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(build_dir, "yolact", "requirements.txt")) as f:
+        return f.read().splitlines()
+
+
+def packages():
+    return [
+        'yolact',
+        'yolact.data',
+        'yolact.external',
+        'yolact.layers',
+        'yolact.scripts',
+        'yolact.utils',
+        'yolact.web',
+    ]
+
+
+setuptools.setup(
+    name="yolact",
+    version="0.0.1",
+    author="",
+    long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/dbolya/yolact",
+    packages=packages(),
+    python_requires=">=3.6",
+    install_requires=read_requirements(),
+    include_package_data=True,
+    package_data={'': ['yolact/data/*']},
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Education",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    ]
+)


### PR DESCRIPTION
The goal of this PR is to auto-build a `yolact` wheel

* Add a `build_wheel.sh` bash script to build a yolact wheel and test installation
* Add a `setup.py` file to guide building process
* Add a `MANIFEST.in` for assets to be included in wheel
* Add a GHA Workflow for auto-build nightly
* Add a GHA Workflow for auto-building release branch

TODO: 
- [x] ~Fix Relative imports bug caught by @KSGulin~
- [x] ~Remove `auto-build` branch from GHA, only keep master~
- [x] ~Setup release tags/Setup an automated workflow for this~