### PR TITLE
YOLACT upgrades according to `SparseML>1.0` standards

### DIFF
--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -1,0 +1,29 @@
+---
+name: Upload Nightly Wheel
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build-wheel:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build wheel
+        run: |
+          ./build_wheel.sh
+          echo "::set-output name=wheel_path::$(find "dist/" -type f -name "*.whl")"
+          echo "::set-output name=wheel_name::$(basename $(find "dist/" -type f -name "*.whl"))"
+        id: build_wheel
+      - name: Upload Wheel Asset
+        id: upload-release-asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_wheel.outputs.wheel_path }}
+          asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
+          tag: "nightly"
+          overwrite: true

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "master"
+      - "yolact-dev"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "master"
-      - "yolact-dev"
-      - "yolact-entry-points"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - "master"
       - "yolact-dev"
+      - "yolact-entry-points"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-release.yml
+++ b/.github/workflows/build-wheel-release.yml
@@ -1,0 +1,38 @@
+---
+name: Upload Release Wheel
+
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  build-wheel:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build wheel
+        run: |
+          ./build_wheel.sh
+          echo "::set-output name=wheel_path::$(ls dist/*.whl)"
+          echo "::set-output name=wheel_name::$(basename $(ls dist/*.whl))"
+        id: build_wheel
+      - name: Get Tag
+        id: extract_tag
+        run: echo "##[set-output name=tag;]$(echo v${GITHUB_REF_NAME#*/})"
+      - name: Tag Repo
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: ${{ steps.extract_tag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Wheel Asset
+        id: upload-release-asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_wheel.outputs.wheel_path }}
+          asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
+          tag: ${{ steps.extract_tag.outputs.tag }}
+          overwrite: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include *.md
+include LICENSE
+include setup.py
+recursive-include yolact/scripts *
+recursive-include yolact/external *
+recursive-include yolact/web *
+include yolact/requirements.txt

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+#************************************************#
+#           build_wheel.sh                       #
+#    Build a Python3 wheel for YOLACT            #
+#************************************************#
+
+REPO_NAME="yolact"
+NEEDED_FOLDERS=("data" "external" "layers" "scripts" "utils" "web")
+REQUIREMENTS_FILE="requirements.txt"
+SETUP_FILE="setup.py"
+PYTHON_EXTENSION=".py"
+PACKAGE_TEST_DIR="/tmp/$USER/pip_package_test"
+
+# --------------------------------------------------------- #
+# main ()                                                   #
+# drives the entire build process                           #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+main() {
+  echo "Starting build ..."
+  pre_build_setup &&
+    build &&
+    post_build_test_and_teardown &&
+    echo "Build Successful ... "
+}
+
+# --------------------------------------------------------- #
+# pre_build_setup ()                                        #
+# performs necessary setup for building a YOLACT wheel      #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+pre_build_setup() {
+  echo "Pre-Build Setup ... "
+  __validate_files && __copy_files && __fix_requirements && __build_setup
+}
+
+# --------------------------------------------------------- #
+# build ()                                                  #
+# actual build happens here                                 #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+build() {
+  echo "Build ... "
+  python3 -m build
+  rm --recursive "${REPO_NAME}"
+}
+
+# --------------------------------------------------------- #
+# post_build_test_and_teardown ()                           #
+# installation check + cleanup unnecessary files            #
+# Returns: 0 on success, non-zero if something goes wrong.  #
+# --------------------------------------------------------- #
+post_build_test_and_teardown() {
+  echo "Post-Build Test and Teardowns ... "
+  __test_build
+  __teardown
+}
+
+__validate_files() {
+  echo "Validating files ... "
+  # venv
+  if [[ ! -e "$(command -v python3)" ]]; then
+    echo "Is python installed?" 1>&2
+    return 1
+  fi
+
+  # setup.py
+  if [[ ! -e "${SETUP_FILE}" ]]; then
+    echo "${SETUP_FILE} file not found" 1>&2
+    return 3
+  fi
+}
+
+__copy_files() {
+  echo "Copying files ... "
+
+  # create empty yolact dir, overwrite if exists
+  [[ -d ${REPO_NAME} ]] && rm --recursive ${REPO_NAME}
+  mkdir --parents "${REPO_NAME}"
+
+  for folder in "${NEEDED_FOLDERS[@]}"; do
+    cp --recursive "${folder}" "${REPO_NAME}"
+  done
+
+  echo "Copying ${REQUIREMENTS_FILE} ... "
+  cp "${REQUIREMENTS_FILE}" "${REPO_NAME}"
+
+  echo "Finding and Copying Python Files ... "
+  find . -maxdepth 1 -type f -name "*${PYTHON_EXTENSION}" -exec cp {} "${REPO_NAME}" \;
+
+}
+
+__fix_requirements() {
+  echo "Fixing ${REQUIREMENTS_FILE} ... "
+  sed -i '/^sparseml/d' "${REPO_NAME}/${REQUIREMENTS_FILE}"
+
+  echo "Fixing folder level imports ... "
+  for folder in "${NEEDED_FOLDERS[@]}"; do
+    __fix_imports "${folder}"
+  done
+
+  echo "Fixing file level imports ... "
+  find "${REPO_NAME}" -maxdepth 1 -type f -name "*${PYTHON_EXTENSION}" -print0 | while read -r -d $'\0' file; do
+    __fix_imports "${file}"
+  done
+
+}
+
+__fix_imports() {
+  curr_import_name=$(echo "${1}" | sed -E "s/.*\/(.*)\.py$/\1/")
+
+  echo "Fixing top level imports for ${curr_import_name} ... "
+  grep --include="*.py" -rnl "${REPO_NAME}/" -e "import ${curr_import_name}" | xargs -i@ sed -i "s/^import ${curr_import_name} /import ${REPO_NAME}.${curr_import_name} /g" @
+
+  echo "Fixing from imports for ${curr_import_name} ... "
+  grep --include="*.py" -rnl "${REPO_NAME}/" -e "from ${curr_import_name} " | xargs -i@ sed -i "s/^from ${curr_import_name} /from ${REPO_NAME}.${curr_import_name} /g" @
+
+}
+
+__build_setup() {
+  # install build-tools
+  python3 -m pip install --upgrade build
+
+  package_name="$(python3 ${SETUP_FILE} --name)"
+  package_version="$(python3 ${SETUP_FILE} --version)"
+
+  if [[ -z "$package_name" || -z "$package_version" ]]; then
+    echo "Could not determine package name/version (found ${package_name}==${package_version})" 1>&2
+    return 4
+  fi
+  echo "Package: ${package_name}==${package_version}"
+
+  # Cleanup old dist folder
+  if [[ -e dist ]]; then
+    echo "Removing old releases in dist/* ... "
+    rm --recursive --force dist/ || return 5
+  fi
+
+  echo "NM_INTEGRATED=True" >>"${REPO_NAME}/__init__.py"
+}
+
+__test_build() {
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "${PACKAGE_TEST_DIR}" || return 11
+  whl_file=$(find "dist/" -type f -name "*.whl")
+
+  echo "Attempting to install ${whl_file}"
+  python3 -m pip install --target "${PACKAGE_TEST_DIR}" --upgrade "${whl_file}"
+  package_was_installed="$?"
+
+  if [[ "${package_was_installed}" -ne "0" ]]; then
+    echo "FAILED TO INSTALL ${whl_file} (status=${package_was_installed})" 1>&2
+    return 13
+  fi
+
+  echo "Example change in imports .... for a file backbone.py"
+  grep --include="*.py" -rn "${PACKAGE_TEST_DIR}/${REPO_NAME}/" -e "from yolact.backbone" || return 1
+
+  echo "Example change in imports .... for a folder utils"
+  grep --include="*.py" -rn "${PACKAGE_TEST_DIR}/${REPO_NAME}/" -e "from yolact.utils" || return 1
+}
+
+__teardown() {
+  echo "Removing ${PACKAGE_TEST_DIR} ... "
+  rm --recursive --force "${PACKAGE_TEST_DIR}" || return 12
+}
+
+main

--- a/eval.py
+++ b/eval.py
@@ -365,7 +365,12 @@ def parse_args(argv=None):
     parser.add_argument('--num_iterations', default=0, type=int, help="The num of iterations to run the engine for, defaults to the validation set")
     parser.add_argument('--batch_size', default=1, type=int, help="The batch size to use the engine for, defaults to 1. Only available for benchmark mode")
     parser.add_argument('--engine', default=None, choices=Engine.supported(), help=f'Engine to use for evaluation choices are {Engine.supported()}')
-
+    parser.add_argument('--validation_info', default=None, type=str,
+                        help='If specified, override the validation info json  path '
+                             'specified in the config with this one.')
+    parser.add_argument('--validation_images', default=None, type=str,
+                        help='If specified, override the validation images path path '
+                             'specified in the config with this one.')
     parser.set_defaults(no_bar=False, display=False, resume=False, output_coco_json=False, output_web_json=False, shuffle=False,
                         benchmark=False, no_sort=False, no_hash=False, mask_proto_debug=False, crop=True, detect=False, display_fps=False,
                         emulate_playback=False)
@@ -1443,6 +1448,9 @@ def main():
 
         if args.image is None and args.video is None and args.images is None:
             if not args.benchmark:
+                cfg.dataset.valid_images = args.validation_images or cfg.dataset.valid_images
+                cfg.dataset.valid_info = args.validation_info or cfg.dataset.valid_info
+
                 dataset = COCODetection(cfg.dataset.valid_images,
                                         cfg.dataset.valid_info,
                                         transform=BaseTransform(),

--- a/eval.py
+++ b/eval.py
@@ -1393,7 +1393,8 @@ def get_engine(model_filepath: str, engine=None):
     )
 
 
-if __name__ == '__main__':
+def main():
+    global args
     parse_args()
     if args.config is not None:
         set_cfg(args.config)
@@ -1442,14 +1443,16 @@ if __name__ == '__main__':
 
         if args.image is None and args.video is None and args.images is None:
             if not args.benchmark:
-                dataset = COCODetection(cfg.dataset.valid_images, cfg.dataset.valid_info,
-                                    transform=BaseTransform(), has_gt=cfg.dataset.has_gt)
+                dataset = COCODetection(cfg.dataset.valid_images,
+                                        cfg.dataset.valid_info,
+                                        transform=BaseTransform(),
+                                        has_gt=cfg.dataset.has_gt)
                 prep_coco_cats()
             else:
                 zoo_model = zoo_yolo_v3()
                 dataset = load_numpy_list(zoo_model.data_originals.downloaded_path())
         else:
-            dataset = None        
+            dataset = None
 
         print('Loading model...', end='')
 
@@ -1459,7 +1462,8 @@ if __name__ == '__main__':
                                     batch_size=args.batch_size
                                     )
         elif args.engine == Engine.ORT:
-            net = ORTWrapper(filepath=args.trained_model, cfg=cfg, batch_size = args.batch_size)
+            net = ORTWrapper(filepath=args.trained_model, cfg=cfg,
+                             batch_size=args.batch_size)
         else:
             net = Yolact()
             net.load_checkpoint(args.trained_model)
@@ -1470,5 +1474,9 @@ if __name__ == '__main__':
             net = net.cuda()
 
         evaluate(net, dataset)
+
+
+if __name__ == '__main__':
+    main()
 
 

--- a/export.py
+++ b/export.py
@@ -219,6 +219,10 @@ def export(args: ExportArgs):
     logging.info(f"Model checkpoint exported to {args.name}")
 
 
-if __name__ == "__main__":
+def main():
     export_args = parse_args()
     export(export_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_coco_eval.py
+++ b/run_coco_eval.py
@@ -18,9 +18,7 @@ parser.add_argument('--eval_type',     default='both', choices=['bbox', 'mask', 
 args = parser.parse_args()
 
 
-
-if __name__ == '__main__':
-
+def main():
 	eval_bbox = (args.eval_type in ('bbox', 'both'))
 	eval_mask = (args.eval_type in ('mask', 'both'))
 
@@ -37,13 +35,17 @@ if __name__ == '__main__':
 		bbox_eval.evaluate()
 		bbox_eval.accumulate()
 		bbox_eval.summarize()
-	
+
 	if eval_mask:
 		print('\nEvaluating Masks:')
 		bbox_eval = COCOeval(gt_annotations, mask_dets, 'segm')
 		bbox_eval.evaluate()
 		bbox_eval.accumulate()
 		bbox_eval.summarize()
+
+
+if __name__ == '__main__':
+	main()
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import os
+import setuptools
+from setuptools import find_packages
+
+
+def read_requirements():
+    build_dir = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(build_dir, "yolact", "requirements.txt")) as f:
+        return f.read().splitlines()
+
+
+def packages():
+    return find_packages(
+        exclude=["*.__pycache__.*"]
+    )
+
+
+
+setuptools.setup(
+    name="yolact",
+    version="0.0.1",
+    author="",
+    long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/dbolya/yolact",
+    packages=packages(),
+    python_requires=">=3.6",
+    install_requires=read_requirements(),
+    include_package_data=True,
+    package_data={'': ['yolact/data/*']},
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Education",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    ]
+)

--- a/train.py
+++ b/train.py
@@ -122,6 +122,7 @@ Some Useful Model Stubs:
 
 """
 import logging
+from pathlib import Path
 
 from sparseml.pytorch.utils import TensorBoardLogger
 from torch.cuda import amp
@@ -344,6 +345,13 @@ def train():
     net = yolact_net
     net.train()
 
+    metadata = {
+        "batch_size": args.batch_size,
+        "train_info": Path(cfg.dataset.train_info).name,
+        "validation_info": Path(cfg.dataset.valid_info).name,
+        "config": cfg.name,
+    }
+
     if args.log:
         log = Log(cfg.name, args.log_folder, dict(args._get_kwargs()),
             overwrite=(args.resume is None), log_gpu_stats=args.log_gpu)
@@ -371,6 +379,7 @@ def train():
             path=args.resume,
             train_recipe=args.recipe,
             resume=args.cont,
+            metadata=metadata,
         )
         args.recipe = train_recipe
         if args.start_iter == -1:
@@ -381,6 +390,7 @@ def train():
         sparseml_wrapper = SparseMLWrapper(
             model=yolact_net,
             recipe=args.recipe,
+            metadata=metadata,
         )
         # A new run always starts from epoch 0
         sparseml_wrapper.initialize(start_epoch=0)

--- a/train.py
+++ b/train.py
@@ -196,6 +196,14 @@ parser.add_argument('--keep_latest_interval', default=100000, type=int,
                     help='When --keep_latest is on, don\'t delete the latest file at these intervals. This should be a multiple of save_interval or 0.')
 parser.add_argument('--dataset', default=None, type=str,
                     help='If specified, override the dataset specified in the config with this one (example: coco2017_dataset).')
+parser.add_argument('--train_info', default=None, type=str,
+                    help='If specified, override the train info json  path specified in the config with this one.')
+parser.add_argument('--validation_info', default=None, type=str,
+                    help='If specified, override the validation info json  path specified in the config with this one.')
+parser.add_argument('--train_images', default=None, type=str,
+                    help='If specified, override the train images  path specified in the config with this one.')
+parser.add_argument('--validation_images', default=None, type=str,
+                    help='If specified, override the validation images path path specified in the config with this one.')
 parser.add_argument('--no_log', dest='log', action='store_false',
                     help='Don\'t log per iteration information into log_folder.')
 parser.add_argument('--log_gpu', dest='log_gpu', action='store_true',
@@ -314,12 +322,19 @@ def train():
     if not os.path.exists(args.save_folder):
         os.mkdir(args.save_folder)
 
+    cfg.dataset.train_images = args.train_images or cfg.dataset.train_images
+    cfg.dataset.train_info = args.train_info or cfg.dataset.train_info
+
     dataset = COCODetection(image_path=cfg.dataset.train_images,
                             info_file=cfg.dataset.train_info,
                             transform=SSDAugmentation(MEANS))
-    
+
+
     if args.validation_epoch > 0:
         setup_eval()
+        cfg.dataset.valid_images = args.train_images or cfg.dataset.valid_images
+        cfg.dataset.valid_info = args.train_info or cfg.dataset.valid_info
+
         val_dataset = COCODetection(image_path=cfg.dataset.valid_images,
                                     info_file=cfg.dataset.valid_info,
                                     transform=BaseTransform(MEANS))

--- a/train.py
+++ b/train.py
@@ -332,8 +332,8 @@ def train():
 
     if args.validation_epoch > 0:
         setup_eval()
-        cfg.dataset.valid_images = args.train_images or cfg.dataset.valid_images
-        cfg.dataset.valid_info = args.train_info or cfg.dataset.valid_info
+        cfg.dataset.valid_images = args.validation_images or cfg.dataset.valid_images
+        cfg.dataset.valid_info = args.validation_info or cfg.dataset.valid_info
 
         val_dataset = COCODetection(image_path=cfg.dataset.valid_images,
                                     info_file=cfg.dataset.valid_info,

--- a/train.py
+++ b/train.py
@@ -710,5 +710,9 @@ def compute_validation_map(epoch, iteration, yolact_net, dataset, log:Log=None):
 def setup_eval():
     eval_script.parse_args(['--no_bar', '--max_images='+str(args.validation_size)])
 
-if __name__ == '__main__':
+
+def main():
     train()
+
+if __name__ == '__main__':
+    main()

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch.nn as nn
 from sparseml.pytorch.optim import ScheduledModifierManager
@@ -35,12 +35,14 @@ class SparseMLWrapper(object):
         recipe: str,
         checkpoint_recipe: Optional[str] = None,
         checkpoint_epoch: Union[int, float] = float('inf'),
+        metadata: Optional[Dict[str, any]] = None,
     ):
         self.enabled = bool(recipe)
         self.model = model.module if is_parallel(model) else model
         self.recipe = recipe
         self.manager = ScheduledModifierManager.from_yaml(
-            recipe
+            file_path=recipe,
+            metadata=metadata,
         ) if self.enabled else None
         self.logger = None
         self.checkpoint_recipe_manager = ScheduledModifierManager.from_yaml(

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -45,15 +45,15 @@ class SparseMLWrapper(object):
         if not self.enabled or rank not in [-1, 0]:
             return
 
-        def _logging_lambda(log_tag, log_val, log_vals, step, walltime):
+        def _logging_lambda(tag, value, values, step, wall_time, **kwargs):
             if not wandb_logger or not wandb_available:
                 return
 
-            if log_val is not None:
-                wandb.log({log_tag: log_val})
+            if value is not None:
+                wandb.log({tag: value})
 
-            if log_vals:
-                wandb.log(log_vals)
+            if values:
+                wandb.log(values)
 
         self.manager.initialize_loggers([
             SparsificationGroupLogger(

--- a/yolact.py
+++ b/yolact.py
@@ -6,7 +6,7 @@ from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
 from math import sqrt
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from collections import defaultdict
 
 from data.config import cfg, mask_type
@@ -488,12 +488,14 @@ class Yolact(nn.Module):
         path: str,
         train_recipe: Optional[str] = None,
         resume: bool = False,
+        metadata: Optional[Dict[str, any]] = None,
     ) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
         :param path: local path to the checkpoint
         :param train_recipe: A train recipe if different from checkpoint recipe
         :param resume: True if resuming a last run
+        :param metadata: Optional metadata to be stored with recipe
         :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """
@@ -508,6 +510,7 @@ class Yolact(nn.Module):
             recipe=train_recipe,
             checkpoint_recipe=checkpoint_recipe,
             checkpoint_epoch=float('inf') if not resume else checkpoint_epoch,
+            metadata=metadata,
         )
 
         # For backward compatability, remove these (the new variable is called layers)

--- a/yolact.py
+++ b/yolact.py
@@ -1,6 +1,7 @@
 import torch, torchvision
 import torch.nn as nn
 import torch.nn.functional as F
+from sparseml.pytorch.optim import ScheduledModifierManager
 from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
@@ -478,22 +479,36 @@ class Yolact(nn.Module):
         checkpoint = {
                          'epoch': epoch,
                          'model_state_dict': self.state_dict(),
-                         'recipe': recipe,
+                         'checkpoint_recipe': recipe,
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(
+        self,
+        path: str,
+        train_recipe: Optional[str] = None,
+        resume: bool = False,
+    ) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
-        :return: A tuple containing the epoch and the recipe if
+        :param path: local path to the checkpoint
+        :param train_recipe: A train recipe if different from checkpoint recipe
+        :param resume: True if resuming a last run
+        :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """
 
-        checkpoint = torch.load(path)
-        epoch = checkpoint.get('epoch')
-        recipe = recipe or checkpoint.get('recipe')
-        state_dict = checkpoint.get('model_state_dict', checkpoint)
-        sparseml_wrapper = SparseMLWrapper(self, recipe)
+        loaded_checkpoint = torch.load(path)
+        checkpoint_epoch = loaded_checkpoint.get('epoch', float('inf'))
+        checkpoint_recipe = loaded_checkpoint.get('checkpoint_recipe')
+        state_dict = loaded_checkpoint.get('model_state_dict', loaded_checkpoint)
+
+        sparseml_wrapper = SparseMLWrapper(
+            model=self,
+            recipe=train_recipe,
+            checkpoint_recipe=checkpoint_recipe,
+            checkpoint_epoch=float('inf') if not resume else checkpoint_epoch,
+        )
 
         # For backward compatability, remove these (the new variable is called layers)
         for key in list(state_dict.keys()):
@@ -514,10 +529,20 @@ class Yolact(nn.Module):
                 self.load_state_dict(state_dict)
 
                 loaded = True
-            sparseml_wrapper.initialize(start_epoch=epoch or 0 if resume else 0)
+            start_epoch = 0
+
+            if resume and checkpoint_epoch != float('inf'):
+                start_epoch = checkpoint_epoch
+
+            sparseml_wrapper.initialize(start_epoch=start_epoch)
         if not loaded:
             self.load_state_dict(state_dict=state_dict)
-        return epoch or 0, recipe, sparseml_wrapper
+
+        start_epoch = 0
+        if resume and checkpoint_epoch != float('inf'):
+            start_epoch = checkpoint_epoch
+
+        return start_epoch, train_recipe, sparseml_wrapper
 
     def init_weights(self, backbone_path):
         """ Initialize weights for training. """


### PR DESCRIPTION
This PR represents the main feature branch for all YOLACT related updated. In it's current setup, any feature pushed to this branch ios automatically added to the nightly wheel. **NOTE: remove `yolact-dev` from GHA workflows before merging to `master`**

Features merged to this branch "and" in the nightly wheel:

- [X] YOLACT `build_wheel.sh`: Adds a bash script to build a wheel from the yolact repo, along with GHA workflow to auto invoke build script on push to main and release branches.

Quick Tests:
from inside the yolact directory, activate a virtual env, and then invoke the script
```bash
$python -m venv venv && source venv/bin/activate && bash build_wheel.sh
```

To check auto-wheel hosting, kindly push a small change into the master or release branch; or add a new-branch to the GHA workflow file and push a change there, the wheel generation should be visible in the actions tab

- [X] importable callables for the following scripts, for usage in sparseml

The Scripts:

     * `train.py`
     * `export.py`
     * `run_coco_eval.py`
     * `export.py`
The latest NM YOLACT wheel can be installed from sparseml side by

```python
import sparseml.yolact
```
and the corresponding main functions can be invoked like the following:

```python
def export():
    from yolact.export import main as run_export

    run_export()


def train():
    from yolact.train import main as run_train

    run_train()


def val():
    from yolact.eval import main as run_val

    run_val() 
```

- [x] Support to override data directory for train + validation info and images PR #33 

Yolact repo in it's current state did not support a custom data directory for validation and training info + images; this PR adds in support for that. It adds in the following four CLI args:

```
--train_info
--validation_info
--train_images
--validation_images
```

It also includes a minor Logging bugfix as per updates.

Use the scripts given to download data

`bash data/scripts/COCO.sh ~/datasets/coco`
Example run tested locally:
```bash
python train.py --resume \
zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
--recipe zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images
```

This can be invoked from sparseml side like the following:
```bash
sparseml.yolact.train --resume \
zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
--recipe zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images
```
Output(Truncated):
```bash
loading annotations into memory...
Done (t=11.60s)
creating index...
index created!
loading annotations into memory...
Done (t=13.34s)
creating index...
index created!
Resuming training, loading checkpoint /home/rahul/.cache/sparsezoo/9eb1f165-c111-4d33-8375-ae2db87866c1/pytorch/model.pth...
Begin training!

2022-07-07 15:33:39 __main__     INFO     Overriding number of epochs from SparseML manager to 30
num epochs: 30
Steps to train: 439770
/home/rahul/projects/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/projects/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/projects/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/projects/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
[  0]       0 || B: 1.571 | C: 2.054 | M: 2.769 | S: 0.536 | T: 6.930 || ETA: 0:00:00 || timer: 9.838
[  0]      10 || B: 1.788 | C: 2.293 | M: 2.888 | S: 0.464 | T: 7.434 || ETA: 2 days, 3:35:46.413477 || timer: 0.418
[  0]      20 || B: 1.563 | C: 2.130 | M: 2.576 | S: 0.456 | T: 6.725 || ETA: 2 days, 3:13:15.099446 || timer: 0.426
[  0]      30 || B: 1.505 | C: 2.075 | M: 2.511 | S: 0.504 | T: 6.595 || ETA: 2 days, 2:47:04.572744 || timer: 0.417
[  0]      40 || B: 1.519 | C: 2.084 | M: 2.519 | S: 0.468 | T: 6.590 || ETA: 2 days, 2:40:02.884557 || timer: 0.405
[  0]      50 || B: 1.540 | C: 2.074 | M: 2.551 | S: 0.441 | T: 6.606 || ETA: 2 days, 2:36:00.802207 || timer: 0.403
```

Note:
if the script needs to be called from within yolact(and not sparseml) then the newly added args can be ignored, albeit the data must be present in the default directory, to download coco to the default directory invoke respective script with no arguments like the following: `bash data/scripts/COCO.sh`; then use the following command:

```bash
python train.py --resume \
zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
--recipe zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/pruned90-none
```

- [x] Recipe Stages PR #29 To be merged, adds in support for composing recipes and staged runs
- [x] Metadata Support PR #34 To be merged, adds in support for storing metadata in checkpoint_recipes

TODO
- [x] Remove yolact-dev triggers from GHA 