### PR TITLE
Added support for recipe-metadata

### DIFF
--- a/train.py
+++ b/train.py
@@ -122,6 +122,7 @@ Some Useful Model Stubs:
 
 """
 import logging
+from pathlib import Path
 
 from sparseml.pytorch.utils import TensorBoardLogger
 from torch.cuda import amp
@@ -344,6 +345,13 @@ def train():
     net = yolact_net
     net.train()
 
+    metadata = {
+        "batch_size": args.batch_size,
+        "train_info": Path(cfg.dataset.train_info).name,
+        "validation_info": Path(cfg.dataset.valid_info).name,
+        "config": cfg.name,
+    }
+
     if args.log:
         log = Log(cfg.name, args.log_folder, dict(args._get_kwargs()),
             overwrite=(args.resume is None), log_gpu_stats=args.log_gpu)
@@ -371,6 +379,7 @@ def train():
             path=args.resume,
             train_recipe=args.recipe,
             resume=args.cont,
+            metadata=metadata,
         )
         args.recipe = train_recipe
         if args.start_iter == -1:
@@ -381,6 +390,7 @@ def train():
         sparseml_wrapper = SparseMLWrapper(
             model=yolact_net,
             recipe=args.recipe,
+            metadata=metadata,
         )
         # A new run always starts from epoch 0
         sparseml_wrapper.initialize(start_epoch=0)

--- a/train.py
+++ b/train.py
@@ -367,21 +367,23 @@ def train():
 
     if args.resume and args.resume.lower() not in ("no", "false", "f", "0"):
         print('Resuming training, loading checkpoint {}...'.format(args.resume))
-        checkpoint_epoch, checkpoint_recipe, sparseml_wrapper = yolact_net.load_checkpoint(args.resume, args.recipe, resume=args.cont)
-        start_epoch = 0
-        if checkpoint_epoch and args.cont:
-            start_epoch = checkpoint_epoch
-        if not args.use_checkpoint_epoch:
-            start_epoch = 0
-        args.recipe = args.recipe or checkpoint_recipe
+        start_epoch, train_recipe, sparseml_wrapper = yolact_net.load_checkpoint(
+            path=args.resume,
+            train_recipe=args.recipe,
+            resume=args.cont,
+        )
+        args.recipe = train_recipe
         if args.start_iter == -1:
             args.start_iter = SavePath.from_str(args.resume).iteration
     else:
         print('Initializing weights...')
         yolact_net.init_weights(backbone_path=args.save_folder + cfg.backbone.path)
-        start_epoch= 0
-        sparseml_wrapper = SparseMLWrapper(yolact_net, args.recipe)
-        sparseml_wrapper.initialize(start_epoch=start_epoch)
+        sparseml_wrapper = SparseMLWrapper(
+            model=yolact_net,
+            recipe=args.recipe,
+        )
+        # A new run always starts from epoch 0
+        sparseml_wrapper.initialize(start_epoch=0)
 
     optimizer = optim.SGD(net.parameters(), lr=args.lr, momentum=args.momentum,
                           weight_decay=args.decay)
@@ -454,7 +456,7 @@ def train():
                 half_precision = False
 
             # Resume from start_iter
-            if (epoch+1)*epoch_size < iteration:
+            if (epoch+1) * epoch_size < iteration:
                 continue
             
             for datum in data_loader:
@@ -561,7 +563,8 @@ def train():
                     yolact_net.save_checkpoint(
                         save_path(epoch, iteration),
                         recipe=sparseml_wrapper.state_dict().get('recipe'),
-                        epoch=epoch)
+                        epoch=epoch,
+                    )
 
                     if args.keep_latest and latest is not None:
                         if args.keep_latest_interval <= 0 or iteration % args.keep_latest_interval != args.save_interval:

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -56,7 +56,7 @@ class SparseMLWrapper(object):
 
     def state_dict(self):
         """
-        :return: A dict object with compsed recipe
+        :return: A dict object with composed recipe
         """
         return {
             'recipe': str(self.compose_recipes()) if self.enabled else None,
@@ -137,7 +137,7 @@ class SparseMLWrapper(object):
     def should_override_scheduler(self):
         return self.enabled and self.manager.learning_rate_modifiers
 
-    def check_epoch_override(self, epochs):
+    def check_epoch_override(self, epochs) -> Union[int, float]:
         """
         Override num epochs if recipe explicitly modifies epoch range
 
@@ -153,7 +153,7 @@ class SparseMLWrapper(object):
 
         return epochs
 
-    def qat_active(self, epoch):
+    def qat_active(self, epoch) -> bool:
         """
         :param epoch: Epoch number to test for
         :return: True if qat active at specified epoch else False

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch.nn as nn
 from sparseml.pytorch.optim import ScheduledModifierManager
@@ -35,12 +35,14 @@ class SparseMLWrapper(object):
         recipe: str,
         checkpoint_recipe: Optional[str] = None,
         checkpoint_epoch: Union[int, float] = float('inf'),
+        metadata: Optional[Dict[str, any]] = None,
     ):
         self.enabled = bool(recipe)
         self.model = model.module if is_parallel(model) else model
         self.recipe = recipe
         self.manager = ScheduledModifierManager.from_yaml(
-            recipe
+            file_path=recipe,
+            metadata=metadata,
         ) if self.enabled else None
         self.logger = None
         self.checkpoint_recipe_manager = ScheduledModifierManager.from_yaml(

--- a/yolact.py
+++ b/yolact.py
@@ -1,6 +1,7 @@
 import torch, torchvision
 import torch.nn as nn
 import torch.nn.functional as F
+from sparseml.pytorch.optim import ScheduledModifierManager
 from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
@@ -478,22 +479,28 @@ class Yolact(nn.Module):
         checkpoint = {
                          'epoch': epoch,
                          'model_state_dict': self.state_dict(),
-                         'recipe': recipe,
+                         'checkpoint_recipe': recipe,
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(self, path, train_recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
-        :return: A tuple containing the epoch and the recipe if
+        :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """
 
-        checkpoint = torch.load(path)
-        epoch = checkpoint.get('epoch')
-        recipe = recipe or checkpoint.get('recipe')
-        state_dict = checkpoint.get('model_state_dict', checkpoint)
-        sparseml_wrapper = SparseMLWrapper(self, recipe)
+        loaded_checkpoint = torch.load(path)
+        checkpoint_epoch = loaded_checkpoint.get('epoch', float('inf'))
+        checkpoint_recipe = loaded_checkpoint.get('checkpoint_recipe')
+        state_dict = loaded_checkpoint.get('model_state_dict', loaded_checkpoint)
+
+        sparseml_wrapper = SparseMLWrapper(
+            model=self,
+            recipe=train_recipe,
+            checkpoint_recipe=checkpoint_recipe,
+            checkpoint_epoch=float('inf') if not resume else checkpoint_epoch,
+        )
 
         # For backward compatability, remove these (the new variable is called layers)
         for key in list(state_dict.keys()):
@@ -514,10 +521,20 @@ class Yolact(nn.Module):
                 self.load_state_dict(state_dict)
 
                 loaded = True
-            sparseml_wrapper.initialize(start_epoch=epoch or 0 if resume else 0)
+            start_epoch = 0
+
+            if resume and checkpoint_epoch != float('inf'):
+                start_epoch = checkpoint_epoch
+
+            sparseml_wrapper.initialize(start_epoch=start_epoch)
         if not loaded:
             self.load_state_dict(state_dict=state_dict)
-        return epoch or 0, recipe, sparseml_wrapper
+
+        start_epoch = 0
+        if resume and checkpoint_epoch != float('inf'):
+            start_epoch = checkpoint_epoch
+
+        return start_epoch, train_recipe, sparseml_wrapper
 
     def init_weights(self, backbone_path):
         """ Initialize weights for training. """

--- a/yolact.py
+++ b/yolact.py
@@ -6,7 +6,7 @@ from torchvision.models.resnet import Bottleneck
 import numpy as np
 from itertools import product
 from math import sqrt
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from collections import defaultdict
 
 from data.config import cfg, mask_type
@@ -488,12 +488,14 @@ class Yolact(nn.Module):
         path: str,
         train_recipe: Optional[str] = None,
         resume: bool = False,
+        metadata: Optional[Dict[str, any]] = None,
     ) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
         :param path: local path to the checkpoint
         :param train_recipe: A train recipe if different from checkpoint recipe
         :param resume: True if resuming a last run
+        :param metadata: Optional metadata to be stored with recipe
         :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """
@@ -508,6 +510,7 @@ class Yolact(nn.Module):
             recipe=train_recipe,
             checkpoint_recipe=checkpoint_recipe,
             checkpoint_epoch=float('inf') if not resume else checkpoint_epoch,
+            metadata=metadata,
         )
 
         # For backward compatability, remove these (the new variable is called layers)

--- a/yolact.py
+++ b/yolact.py
@@ -483,9 +483,17 @@ class Yolact(nn.Module):
                      }
         torch.save(checkpoint, path)
 
-    def load_checkpoint(self, path, train_recipe=None, resume: bool = False) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
+    def load_checkpoint(
+        self,
+        path: str,
+        train_recipe: Optional[str] = None,
+        resume: bool = False,
+    ) -> Tuple[Optional[int], Optional[str], SparseMLWrapper]:
         """ Loads weights into the current Yolact object.
 
+        :param path: local path to the checkpoint
+        :param train_recipe: A train recipe if different from checkpoint recipe
+        :param resume: True if resuming a last run
         :return: A tuple containing the epoch and the checkpoint_recipe if
             found in the checkpoint, and a SparseML Wrapper instance
         """


### PR DESCRIPTION
This PR adds in support for storing metadata in checkpoint_recipes for yolact, A training flow was interrupted in the middle and checkpoint recipe was evaluated

Interrupted Training run:
```bash
sparseml.yolact.train \
--recipe /home/rahul/projects/yolact/recipes/small-quant.yaml \
--resume "zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none" \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images \
--save_folder ./quant-checkpoint-with-recipe-metadata
```

```python
In [1]: import torch

In [2]: import pprint as pp

In [3]: ckpt = torch.load("quant-checkpoint-with-recipe-metadata/yolact_darknet53_0_24_interrupt.pth")

In [4]: pp.pprint(ckpt["checkpoint_recipe"])
('version: 1.1.0\n'
 '\n'
 '__metadata__:\n'
 '  batch_size: 8\n'
 '  train_info: instances_train2017.json\n'
 '  validation_info: instances_val2017.json\n'
 '  config: yolact_darknet53\n'
 '  framework_metadata:\n'
 '    python_version: 3.8.12\n'
 '    sparseml_version: 1.1.0.20220708\n'
 '    torch_version: 1.7.1\n'
 '\n'
 'modifiers:\n'
 '    - !EpochRangeModifier\n'
 '        end_epoch: 2\n'
 '        start_epoch: 0.0\n'
 '\n'
 '    - !LearningRateFunctionModifier\n'
 '        cycle_epochs: 1.0\n'
 '        end_epoch: 2\n'
 '        final_lr: 1e-06\n'
 '        init_lr: 1e-05\n'
 '        lr_func: linear\n'
 '        start_epoch: 0\n'
 '        update_frequency: -1.0\n'
 '\n'
 '    - !ConstantPruningModifier\n'
 '        end_epoch: -1.0\n'
 '        params: __ALL_PRUNABLE__\n'
 '        start_epoch: 0.0\n'
 '        update_frequency: -1\n'
 '\n'
 '    - !QuantizationModifier\n'
 '        activation_bits: 8\n'
 '        disable_quantization_observer_epoch: 1.0\n'
 '        end_epoch: -1.0\n'
 '        exclude_batchnorm: True\n'
 "        exclude_module_types: ['BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d']\n"
 '        freeze_bn_stats_epoch: 1.0\n'
 '        model_fuse_fn_name: conv_bn_relus\n'
 '        quantize_conv_activations: True\n'
 '        quantize_embedding_activations: True\n'
 '        quantize_embeddings: True\n'
 '        quantize_linear_activations: True\n'
 '        reduce_range: False\n'
 '        start_epoch: 0\n'
 '        tensorrt: False\n'
 '        weight_bits: 8\n'
 '\n'
 '    - !SetWeightDecayModifier\n'
 '        constant_logging: False\n'
 '        end_epoch: -1\n'
 '        start_epoch: 0\n'
 '        weight_decay: 0.0\n')

```

Noting: The wheel for this feature is not pushed yet, and can be built + installed locally like the following:
```bash
bash build_wheel.sh && pip install dist/yolact-0.0.1-py3-none-any.whl
```