### PR TITLE
Fixing `--benchmark` happy path + make choosing weights from stub + recipe string arg more robust to the input

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -880,7 +880,6 @@ def evalimages(net:Yolact, input_folder:str, output_folder:str):
     if not os.path.exists(output_folder):
         os.mkdir(output_folder)
 
-    print()
     for p in Path(input_folder).glob('*'): 
         path = str(p)
         name = os.path.basename(path)
@@ -1141,19 +1140,19 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
     cleanup_and_exit()
 
 
-def load_benchmark_batch(dataset, image_idx, use_cuda = True):
+def load_benchmark_batch(dataset, image_idx, device):
     img = dataset[image_idx]['arr_0']
     TARGET_SIZE = 550, 550
     img = cv2.resize(img.transpose(1,2,0), TARGET_SIZE)
     img = np.moveaxis(img, -1, 0) # put channels in front
     _, h, w = img.shape
     batch = torch.from_numpy(np.ascontiguousarray(img[np.newaxis], dtype=np.float32))
-    if use_cuda:
-        batch = batch.to(device)
+    batch = batch.to(device)
+
     return batch, h, w
 
 
-def evaluate(net:Yolact, dataset, use_cuda = True, train_mode=False):
+def evaluate(net:Yolact, dataset, device, train_mode=False):
     net.detect.use_fast_nms = args.fast_nms
     net.detect.use_cross_class_nms = args.cross_class_nms
     cfg.mask_proto_debug = args.mask_proto_debug
@@ -1239,7 +1238,7 @@ def evaluate(net:Yolact, dataset, use_cuda = True, train_mode=False):
                                                                        image_idx)
                 else:
 
-                    batch, h, w = load_benchmark_batch(dataset, image_idx, use_cuda)
+                    batch, h, w = load_benchmark_batch(dataset, image_idx, device)
                     gt, gt_masks, num_crowd, img = None, None, None, None
                 if args.batch_size > 1:
                     # build batch
@@ -1483,7 +1482,7 @@ def main():
         if args.cuda:
             net = net.cuda()
 
-        evaluate(net, dataset, args.cuda)
+        evaluate(net, dataset, device)
 
 
 if __name__ == '__main__':

--- a/eval.py
+++ b/eval.py
@@ -1423,6 +1423,8 @@ def main():
     if args.dataset is not None:
         set_dataset(args.dataset)
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
     with torch.no_grad():
         if not os.path.exists('results'):
             os.makedirs('results')

--- a/utils/zoo.py
+++ b/utils/zoo.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from sparsezoo import Model
 from functools import wraps
+from re import search
 
 
 def is_valid_stub(stub: str) -> bool:
@@ -23,13 +24,13 @@ def check_stub_before_invoke(func):
 
 def _get_model_framework_file(model, path: str):
     available_files = model.training.default.files
-    transfer_request = 'recipe_type=transfer' in path
+    transfer_request = search("recipe(.*)transfer", path)
     checkpoint_available = any([".ckpt" in file.name for file in available_files])
     final_available = any([not ".ckpt" in file.name for file in available_files])
 
     if transfer_request and checkpoint_available:
         # checkpoints are saved for transfer learning use cases,
-        # return checkpoint if avaiable and requested
+        # return checkpoint if available and requested
         return [file for file in available_files if ".ckpt" in file.name][0]
 
     elif final_available:


### PR DESCRIPTION
This fix:
- enables the user to use both `recipe` and `recipe_type` string arg keys (analogously to https://github.com/neuralmagic/yolov5/pull/86)
- fixes the pathway when we run benchmark evaluation using the native framework (torch)

Testing commands:
```bash
python eval.py --engine torch --benchmark
```

```bash
python eval.py --engine deepsparse 
```
