### PR TITLE
Bugfix: Device info not propagated

### DIFF
--- a/train.py
+++ b/train.py
@@ -731,7 +731,7 @@ def compute_validation_map(epoch, iteration, yolact_net, dataset, log:Log=None):
         start = time.time()
         print()
         print("Computing validation mAP (this may take a while)...", flush=True)
-        val_info = eval_script.evaluate(yolact_net, dataset, train_mode=True)
+        val_info = eval_script.evaluate(yolact_net, dataset, device=args.device ,train_mode=True)
         end = time.time()
 
         if log is not None:


### PR DESCRIPTION
As a part of commit `c752f42d` a regression was introduced in the `yolact` train script; the signature of the `evaluate` function in `eval.py` was updated but the changes were not propagated accross all calls. This PR fixes that and adds device info to `evaluate` call in `train.py`. As a local test the evaluate function was run.