### PR TITLE
Remove sparseml as install dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ opencv-python
 pycocotools
 matplotlib
 torchvision<=0.8.2
-sparseml[torchvision]>=1.1


### PR DESCRIPTION
Sparseml dependency not needed since supported pathway is running from sparseml. Including it while running from source will install the latest release of sparseml and give it precedence over the local install