### PR TITLE
Bugfix: Eval with torch + Export

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1411,7 +1411,8 @@ def main():
             trained_model_weights = get_checkpoint_from_stub(args.trained_model)
         else:
             trained_model_weights = get_model_onnx_from_stub(args.trained_model)
-
+    else:
+        trained_model_weights = args.trained_model
     args.engine = get_engine(
         model_filepath=trained_model_weights,
         engine=args.engine,

--- a/export.py
+++ b/export.py
@@ -209,7 +209,7 @@ def export(args: ExportArgs):
     model = Yolact()
     model.export = True
     logging.debug(f"Loading state dict from checkpoint {args.checkpoint}")
-    model.load_checkpoint(args.checkpoint, recipe=args.recipe)
+    model.load_checkpoint(args.checkpoint, train_recipe=args.recipe)
     export_onnx(
         module=model,
         sample_batch=torch.randn(*batch_shape),


### PR DESCRIPTION
This PR fixes 2 bugs:

- with export flow, where an argument name was changed elsewhere but not propagated to this script
- With `eval.py` where a pytorch checkpoint was not being evaluated correctly

Both these flows have been tested locally:

```bash
python eval.py --trained_model ~/yolact_darknet53_0_14658.pth --validation_info ~/datasets/coco/annotations/instances_val2017.json --validation_images ~/datasets/coco/images
loading annotations into memory...
Done (t=0.52s)
creating index...
index created!
Loading model... Done.
Starting (10) Warm up iterations, with a batch of 1, this might take some time
Processing Images  ██████████████████████████████     10 /     10 (100.00%)
Warm up iterations (10) over, starting FPS calc with a batch of 1
Processing Images  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      2 /   4952 ( 0.04%)     4.00 fpsProcessing Images  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      3 /   4952 ( 0.06%)     5.07 fpsProcessing Images  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      4 /   4952 ( 0.08%)     5.74 fpsProcessing Images  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      5 /   4952 ( 0.10%)     6.16 fps
```

```bash
python export.py --checkpoint ~/yolact_darknet53_0_14658.pth --recipe ~/projects/sparseml/quant_small-recipe_yolact.yaml --name my_onnx
INFO:/home/rahul/projects/yolact/utils/sparse.py:Applying structure from checkpoint recipe
.
.
.
INFO:root:Model checkpoint exported to my_onnx/yolact_darknet53_0_14658.onnx
```