### PR TITLE
[Bugfix] Training from backbone

### DIFF
--- a/train.py
+++ b/train.py
@@ -2,19 +2,21 @@
 Script to Train YOLACT models
 
 ####################
-usage: train.py [-h] [--batch_size BATCH_SIZE] [--resume RESUME]
-                [--ckpt CKPT] [--start_iter START_ITER]
-                [--num_workers NUM_WORKERS] [--cuda CUDA] [--lr LR]
-                [--momentum MOMENTUM] [--decay DECAY] [--gamma GAMMA]
-                [--save_folder SAVE_FOLDER] [--log_folder LOG_FOLDER]
-                [--config CONFIG] [--save_interval SAVE_INTERVAL]
+usage: train.py [-h] [--batch_size BATCH_SIZE] [--resume RESUME] [--ckpt CKPT]
+                [--start_iter START_ITER] [--num_workers NUM_WORKERS]
+                [--cuda CUDA] [--lr LR] [--momentum MOMENTUM] [--decay DECAY]
+                [--gamma GAMMA] [--save_folder SAVE_FOLDER]
+                [--log_folder LOG_FOLDER] [--config CONFIG]
+                [--save_interval SAVE_INTERVAL]
                 [--validation_size VALIDATION_SIZE]
                 [--validation_epoch VALIDATION_EPOCH] [--keep_latest]
                 [--keep_latest_interval KEEP_LATEST_INTERVAL]
-                [--dataset DATASET] [--no_log] [--log_gpu] [--no_interrupt]
-                [--batch_alloc BATCH_ALLOC] [--no_autoscale]
-                [--recipe RECIPE]
-                [--use_checkpoint_epoch USE_CHECKPOINT_EPOCH]
+                [--dataset DATASET] [--train_info TRAIN_INFO]
+                [--validation_info VALIDATION_INFO]
+                [--train_images TRAIN_IMAGES]
+                [--validation_images VALIDATION_IMAGES] [--no_log] [--log_gpu]
+                [--backbone] [--no_interrupt] [--batch_alloc BATCH_ALLOC]
+                [--no_autoscale] [--recipe RECIPE] [--use_checkpoint_epoch]
                 [--fp16] [--wandb] [--cont]
 
 Yolact Training Script
@@ -23,13 +25,13 @@ optional arguments:
   -h, --help            show this help message and exit
   --batch_size BATCH_SIZE
                         Batch size for training
-  --resume RESUME       Checkpoint state_dict file to resume training from.
-                        If this is "interrupt", the model will resume
-                        training from the interrupt file. Can also be set
-                        to True;along with the --ckpt argument to resume
-                        training from a SparseZoo stub or local checkpoint
-  --ckpt CKPT           Path to a Yolact checkpoint/SparseZoo stub used
-                        only if --resume is True
+  --resume RESUME       Checkpoint state_dict file to resume training from. If
+                        this is "interrupt", the model will resume training
+                        from the interrupt file. Can also be set to True;along
+                        with the --ckpt argument to resume training from a
+                        SparseZoo stub or local checkpoint
+  --ckpt CKPT           Path to a Yolact checkpoint/SparseZoo stub used only
+                        if --resume is True
   --start_iter START_ITER
                         Resume training at this iter. If this is -1, the
                         iteration will be determined from the file name.
@@ -38,59 +40,70 @@ optional arguments:
                         Number of workers used in dataloading
   --cuda CUDA           Use CUDA to train model
   --lr LR, --learning_rate LR
-                        Initial learning rate. Leave as None to read this
-                        from the config.
-  --momentum MOMENTUM   Momentum for SGD. Leave as None to read this from
+                        Initial learning rate. Leave as None to read this from
                         the config.
+  --momentum MOMENTUM   Momentum for SGD. Leave as None to read this from the
+                        config.
   --decay DECAY, --weight_decay DECAY
-                        Weight decay for SGD. Leave as None to read this
-                        from the config.
-  --gamma GAMMA         For each lr step, what to multiply the lr by. Leave
-                        as None to read this from the config.
+                        Weight decay for SGD. Leave as None to read this from
+                        the config.
+  --gamma GAMMA         For each lr step, what to multiply the lr by. Leave as
+                        None to read this from the config.
   --save_folder SAVE_FOLDER
                         Directory for saving checkpoint models.
   --log_folder LOG_FOLDER
                         Directory for saving logs.
   --config CONFIG       The config object to use. Defaults to
-                        yolact_darknet53_config (for DarkNet-53 backbone)
+                        yolact_darknet53_config (for DarkNet-53 backbone).
+                        Note: Only DarkNet-53 backbone supported
   --save_interval SAVE_INTERVAL
                         The number of iterations between saving the model.
   --validation_size VALIDATION_SIZE
                         The number of images to use for validation.
   --validation_epoch VALIDATION_EPOCH
-                        Output validation information every n iterations.
-                        If -1, do no validation.
-  --keep_latest         Only keep the latest checkpoint instead of each
-                        one.
+                        Output validation information every n iterations. If
+                        -1, do no validation.
+  --keep_latest         Only keep the latest checkpoint instead of each one.
   --keep_latest_interval KEEP_LATEST_INTERVAL
-                        When --keep_latest is on, don't delete the latest
-                        file at these intervals. This should be a multiple
-                        of save_interval or 0.
+                        When --keep_latest is on, don't delete the latest file
+                        at these intervals. This should be a multiple of
+                        save_interval or 0.
   --dataset DATASET     If specified, override the dataset specified in the
                         config with this one (example: coco2017_dataset).
-  --no_log              Don't log per iteration information into
-                        log_folder.
-  --log_gpu             Include GPU information in the logs. Nvidia-smi
-                        tends to be slow, so set this with caution.
+  --train_info TRAIN_INFO
+                        If specified, override the train info json path
+                        specified in the config with this one.
+  --validation_info VALIDATION_INFO
+                        If specified, override the validation info json path
+                        specified in the config with this one.
+  --train_images TRAIN_IMAGES
+                        If specified, override the train images path specified
+                        in the config with this one.
+  --validation_images VALIDATION_IMAGES
+                        If specified, override the validation images path path
+                        specified in the config with this one.
+  --no_log              Don't log per iteration information into log_folder.
+  --log_gpu             Include GPU information in the logs. Nvidia-smi tends
+                        to be slow, so set this with caution.
+  --backbone            Set this flag when starting from a backbone
   --no_interrupt        Don't save an interrupt when KeyboardInterrupt is
                         caught.
   --batch_alloc BATCH_ALLOC
-                        If using multiple GPUS, you can set this to be a
-                        comma separated list detailing which GPUs should
-                        get what local batch size (It should add up to your
-                        total batch size).
-  --no_autoscale        YOLACT will automatically scale the lr and the
-                        number of iterations depending on the batch size.
-                        Set this if you want to disable that.
+                        If using multiple GPUS, you can set this to be a comma
+                        separated list detailing which GPUs should get what
+                        local batch size (It should add up to your total batch
+                        size).
+  --no_autoscale        YOLACT will automatically scale the lr and the number
+                        of iterations depending on the batch size. Set this if
+                        you want to disable that.
   --recipe RECIPE       Path to a sparsification recipe, can also be a
-                        SparseZoo recipe stub, if provided the recipe
-                        stored with the checkpoint is ignored
-  --use_checkpoint_epoch USE_CHECKPOINT_EPOCH
+                        SparseZoo recipe stub, if provided the recipe stored
+                        with the checkpoint is ignored
+  --use_checkpoint_epoch
                         True to to override epoch # saved in the checkpoint.
                         default start epoch is 0
   --fp16                flag to switch off fp16 while training
-  --wandb               Flag to use wandb logging, needs `pip install
-                        wandb`
+  --wandb               Flag to use wandb logging, needs `pip install wandb`
   --cont                Flag to continue application of a halted recipe.
 ####################
 Example Usage:

--- a/yolact.py
+++ b/yolact.py
@@ -482,6 +482,7 @@ class Yolact(nn.Module):
                          'checkpoint_recipe': recipe,
                      }
         torch.save(checkpoint, path)
+        print(f"Checkpoint saved to {path}")
 
     def load_checkpoint(
         self,


### PR DESCRIPTION
This PR fixes a bug introduced by during 1.1 push where yolact weights were not being initialized correctly when a `darket53.pth` backbone was used.

This PR adds an extra `--backbone` flag to handle this special case, and updates the documentation accordingly; Corresponding doc updates will be made on `sparseml` and `deepsparse` side

[small-recipe.yaml]()
```yaml
# General Hyperparams
num_epochs: 3
init_lr: 0.001
num_quantization_epochs: 1
num_pruning_epochs: eval(num_epochs - num_quantization_epochs)
quantization_observer_end_target: 0.5

# Pruning Hyperparams
init_sparsity: 0.2
pruning_start_target: 0
pruning_end_target: 0.5
pruning_update_frequency: 0.2
mask_type: [1, 4]
prune_none_target_sparsity: 0.6
prune_low_target_sparsity: 0.7
prune_mid_target_sparsity: 0.8
prune_high_target_sparsity: 0.85

# quantization hyperparams

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)

  # pruning
  - !SetWeightDecayModifier
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    weight_decay: 0.0005

  - !LearningRateFunctionModifier
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    lr_func: linear
    init_lr: eval(init_lr)
    final_lr: eval(0.01 * init_lr)
  # quantization
  - !SetWeightDecayModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    weight_decay: 0.0

  - !LearningRateFunctionModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    end_epoch: eval(num_epochs)
    lr_func: linear
    init_lr: eval(0.01 * init_lr)
    final_lr: eval(0.001 * init_lr)

pruning_modifiers:
  - !GMPruningModifier
    params:
    - backbone.layers.0.1.conv1.0.weight
    - backbone.layers.0.1.conv2.0.weight
    - backbone.layers.1.0.0.weight
    - backbone.layers.1.1.conv1.0.weight
    - backbone.layers.1.1.conv2.0.weight
    - backbone.layers.1.2.conv1.0.weight
    - backbone.layers.1.2.conv2.0.weight

    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_none_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - backbone.layers.2.0.0.weight
      - backbone.layers.2.1.conv1.0.weight
      - backbone.layers.2.1.conv2.0.weight
      - backbone.layers.2.2.conv1.0.weight
      - backbone.layers.2.2.conv2.0.weight
      - backbone.layers.2.3.conv1.0.weight
      - backbone.layers.2.3.conv2.0.weight
      - backbone.layers.2.4.conv1.0.weight
      - backbone.layers.2.4.conv2.0.weight
      - backbone.layers.2.5.conv1.0.weight
      - backbone.layers.2.5.conv2.0.weight
      - backbone.layers.2.6.conv1.0.weight
      - backbone.layers.2.6.conv2.0.weight
      - backbone.layers.2.7.conv1.0.weight
      - backbone.layers.2.7.conv2.0.weight
      - backbone.layers.2.8.conv1.0.weight
      - backbone.layers.2.8.conv2.0.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_low_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - proto_net.0.weight
      - proto_net.2.weight
      - proto_net.4.weight
      - proto_net.8.weight
      - proto_net.10.weight
      - fpn.lat_layers.0.weight
      - fpn.lat_layers.1.weight
      - fpn.lat_layers.2.weight
      - fpn.pred_layers.0.weight
      - fpn.pred_layers.1.weight
      - fpn.pred_layers.2.weight
      - fpn.downsample_layers.0.weight
      - fpn.downsample_layers.1.weight
      - prediction_layers.0.upfeature.0.weight
      - prediction_layers.0.bbox_layer.weight
      - prediction_layers.0.conf_layer.weight
      - prediction_layers.0.mask_layer.weight
      - semantic_seg_conv.weight

    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_mid_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - backbone.layers.3.0.0.weight
      - backbone.layers.3.1.conv1.0.weight
      - backbone.layers.3.1.conv2.0.weight
      - backbone.layers.3.2.conv1.0.weight
      - backbone.layers.3.2.conv2.0.weight
      - backbone.layers.3.3.conv1.0.weight
      - backbone.layers.3.3.conv2.0.weight
      - backbone.layers.3.4.conv1.0.weight
      - backbone.layers.3.4.conv2.0.weight
      - backbone.layers.3.5.conv1.0.weight
      - backbone.layers.3.5.conv2.0.weight
      - backbone.layers.3.6.conv1.0.weight
      - backbone.layers.3.6.conv2.0.weight
      - backbone.layers.3.7.conv1.0.weight
      - backbone.layers.3.7.conv2.0.weight
      - backbone.layers.3.8.conv1.0.weight
      - backbone.layers.3.8.conv2.0.weight
      - backbone.layers.4.0.0.weight
      - backbone.layers.4.1.conv1.0.weight
      - backbone.layers.4.1.conv2.0.weight
      - backbone.layers.4.2.conv1.0.weight
      - backbone.layers.4.2.conv2.0.weight
      - backbone.layers.4.3.conv1.0.weight
      - backbone.layers.4.3.conv2.0.weight
      - backbone.layers.4.4.conv1.0.weight
      - backbone.layers.4.4.conv2.0.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_high_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    disable_quantization_observer_epoch: eval(num_epochs - (quantization_observer_end_target * num_quantization_epochs))
    freeze_bn_stats_epoch: eval(num_epochs - (quantization_observer_end_target * num_quantization_epochs))
```

The final code was tested with a short circuited run, to test model saving, which was another issue caught by QA, It was verified locally that both the following tests produced a valid checkpoint:

```bash
python train.py \
    --resume zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
    --recipe small-recipe.yaml \
    --train_info ./data/coco/annotations/instances_train2017.json \
    --validation_info ./data/coco/annotations/instances_val2017.json \
    --train_images ./data/coco/images \
    --validation_images ./data/coco/images
```
Output:
```bash
❯ ls weights
yolact_darknet53_0_0.pth
```
The weights directory was purged and a `darknet53.pth` checkpoint was placed in the directory.
```bash
python train.py \
    --resume ./weights/darknet53.pth \
    --recipe "zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none" \
    --train_info ./data/coco/annotations/instances_train2017.json \
    --validation_info ./data/coco/annotations/instances_val2017.json \
    --train_images ./data/coco/images \
    --validation_images ./data/coco/images
```
(Short Circuited after 10 iterations)
Output:
```bash
❯ ls weights
darknet53.pth  yolact_darknet53_0_10.pth
```